### PR TITLE
fix: correct Ruby version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ provider configuration.
 
 ## Requirements
 
-- Ruby >= 3.2
+- Ruby >= 3.1
 - kubectl configured with cluster access (for fetching secrets)
 
 ## Installation


### PR DESCRIPTION
## Description

Updates the minimum Ruby version requirement in the README from 3.2 to 3.1 to match the Gemfile specification.

## Changes

- Updated `README.md` to reflect correct Ruby version requirement (>= 3.1)

## Why

The Gemfile specifies `ruby '>= 3.1'` but the README incorrectly stated `Ruby >= 3.2`. This fixes the documentation to match the actual requirement.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update