### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-12 - Command Injection in Ruby System Calls
+**Vulnerability:** Shell command injection via interpolated strings in system calls (`\``` and `TTY::Command.new.run("string")`).
+**Learning:** Using backticks or passing a single string to a command execution method invokes the system shell, which evaluates shell metacharacters. Even if user input is not directly passed initially, configuration or secret keys containing characters like `;`, `&`, or `|` can lead to arbitrary code execution.
+**Prevention:** Always use an array of arguments for system calls (e.g., `TTY::Command.new.run('cmd', 'arg1', 'arg2')` or `system('cmd', 'arg1')`) to bypass the shell and pass arguments directly to the executable.

--- a/lib/zitadel_tui/client.rb
+++ b/lib/zitadel_tui/client.rb
@@ -162,7 +162,7 @@ module ZitadelTui
     def kubectl_get_secret(name, namespace, key)
       escaped_key = key.gsub('.', '\\.')
       cmd = TTY::Command.new(printer: :null)
-      result = cmd.run("kubectl get secret #{name} -n #{namespace} -o jsonpath='{.data.#{escaped_key}}'",
+      result = cmd.run('kubectl', 'get', 'secret', name, '-n', namespace, '-o', "jsonpath={.data.#{escaped_key}}",
                        only_output_on_error: true).out.strip
       raise ApiError, "Failed to get secret #{name}" if result.empty?
 

--- a/lib/zitadel_tui/commands/idp.rb
+++ b/lib/zitadel_tui/commands/idp.rb
@@ -124,11 +124,12 @@ module ZitadelTui
 
       def kubectl_get_secret(name, namespace, key)
         escaped_key = key.gsub('.', '\\.')
-        cmd = "kubectl get secret #{name} -n #{namespace} -o jsonpath='{.data.#{escaped_key}}'"
-        encoded = `#{cmd}`.strip
-        raise "Secret #{name}/#{key} not found" if encoded.empty?
+        cmd = TTY::Command.new(printer: :null)
+        result = cmd.run('kubectl', 'get', 'secret', name, '-n', namespace, '-o', "jsonpath={.data.#{escaped_key}}",
+                         only_output_on_error: true).out.strip
+        raise "Secret #{name}/#{key} not found" if result.empty?
 
-        Base64.decode64(encoded)
+        Base64.decode64(result)
       end
     end
   end

--- a/spec/examples.txt
+++ b/spec/examples.txt
@@ -1,19 +1,20 @@
-example_id                               | status | run_time        |
----------------------------------------- | ------ | --------------- |
-./spec/zitadel_tui/config_spec.rb[1:1:1] | passed | 0.00055 seconds |
-./spec/zitadel_tui/config_spec.rb[1:2:1] | passed | 0.00018 seconds |
-./spec/zitadel_tui/config_spec.rb[1:2:2] | passed | 0.00018 seconds |
-./spec/zitadel_tui/config_spec.rb[1:3:1] | passed | 0.00035 seconds |
-./spec/zitadel_tui/config_spec.rb[1:4:1] | passed | 0.00021 seconds |
-./spec/zitadel_tui/config_spec.rb[1:4:2] | passed | 0.00019 seconds |
-./spec/zitadel_tui/config_spec.rb[1:4:3] | passed | 0.00114 seconds |
-./spec/zitadel_tui/config_spec.rb[1:5:1] | passed | 0.00018 seconds |
-./spec/zitadel_tui/config_spec.rb[1:5:2] | passed | 0.00017 seconds |
-./spec/zitadel_tui/config_spec.rb[1:5:3] | passed | 0.00052 seconds |
-./spec/zitadel_tui/ui_spec.rb[1:1:1]     | passed | 0.00009 seconds |
-./spec/zitadel_tui/ui_spec.rb[1:1:2]     | passed | 0.00007 seconds |
-./spec/zitadel_tui/ui_spec.rb[1:1:3]     | passed | 0.00062 seconds |
-./spec/zitadel_tui/ui_spec.rb[1:2:1]     | passed | 0.00054 seconds |
-./spec/zitadel_tui/ui_spec.rb[1:3:1]     | passed | 0.00007 seconds |
-./spec/zitadel_tui/ui_spec.rb[1:4:1]     | passed | 0.00007 seconds |
-./spec/zitadel_tui/ui_spec.rb[1:5:1]     | passed | 0.00006 seconds |
+example_id                                 | status | run_time        |
+------------------------------------------ | ------ | --------------- |
+./spec/zitadel_tui/client_spec.rb[1:1:1:1] | passed | 0.01634 seconds |
+./spec/zitadel_tui/config_spec.rb[1:1:1]   | passed | 0.00187 seconds |
+./spec/zitadel_tui/config_spec.rb[1:2:1]   | passed | 0.00061 seconds |
+./spec/zitadel_tui/config_spec.rb[1:2:2]   | passed | 0.00056 seconds |
+./spec/zitadel_tui/config_spec.rb[1:3:1]   | passed | 0.00064 seconds |
+./spec/zitadel_tui/config_spec.rb[1:4:1]   | passed | 0.0006 seconds  |
+./spec/zitadel_tui/config_spec.rb[1:4:2]   | passed | 0.00061 seconds |
+./spec/zitadel_tui/config_spec.rb[1:4:3]   | passed | 0.00169 seconds |
+./spec/zitadel_tui/config_spec.rb[1:5:1]   | passed | 0.00086 seconds |
+./spec/zitadel_tui/config_spec.rb[1:5:2]   | passed | 0.00074 seconds |
+./spec/zitadel_tui/config_spec.rb[1:5:3]   | passed | 0.00365 seconds |
+./spec/zitadel_tui/ui_spec.rb[1:1:1]       | passed | 0.00087 seconds |
+./spec/zitadel_tui/ui_spec.rb[1:1:2]       | passed | 0.00033 seconds |
+./spec/zitadel_tui/ui_spec.rb[1:1:3]       | passed | 0.00019 seconds |
+./spec/zitadel_tui/ui_spec.rb[1:2:1]       | passed | 0.00023 seconds |
+./spec/zitadel_tui/ui_spec.rb[1:3:1]       | passed | 0.0004 seconds  |
+./spec/zitadel_tui/ui_spec.rb[1:4:1]       | passed | 0.00022 seconds |
+./spec/zitadel_tui/ui_spec.rb[1:5:1]       | passed | 0.00251 seconds |


### PR DESCRIPTION
Fixes critical command injection vulnerability in the execution of `kubectl` commands.

*🚨 Severity: CRITICAL
*💡 Vulnerability: Command injection in `kubectl_get_secret` methods due to shell string interpolation in system calls.
*🎯 Impact: Arbitrary code execution if malicious input is supplied via `name`, `namespace` or `key` variables.
*🔧 Fix: Replaced backticks and string-based shell command execution with an array of arguments passed to `TTY::Command.new.run`, bypassing the shell entirely.
*✅ Verification: Verified that the tests (`bundle exec rspec`) and linter (`bundle exec rubocop`) still pass successfully.

---
*PR created automatically by Jules for task [8275562250576924503](https://jules.google.com/task/8275562250576924503) started by @damacus*