### PR TITLE
🛡️ Sentinel: [HIGH] Fix local configuration hijacking vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -16,3 +16,7 @@
 **Vulnerability:** Shell command injection risk when interpolating variables directly into `kubectl`'s `jsonpath` argument (e.g., `jsonpath={.data.#{key}}`).
 **Learning:** Even when avoiding shell wrappers, interpolating user or external data into structured query parameters like `jsonpath` can allow attackers to manipulate the query or cause command execution issues. In this case, malicious secret keys could break the `jsonpath` expression or attempt to inject commands.
 **Prevention:** Always use safe output formats like `-o json` when fetching data with external CLI tools and parse the output using native libraries (e.g., `JSON.parse` in Ruby) rather than relying on the CLI's internal querying mechanisms with interpolated strings.
+## 2025-03-17 - Local Configuration Hijacking Vulnerability
+**Vulnerability:** The configuration was appending the current working directory (`Dir.pwd`) to its search path via `@config.append_path(Dir.pwd)`.
+**Learning:** Adding the current working directory to configuration search paths is a significant security risk. If a user runs the CLI tool from a shared or untrusted directory (like `/tmp`), an attacker can place a malicious configuration file there that overrides legitimate settings (such as pointing `zitadel_url` to a malicious server to steal credentials).
+**Prevention:** Avoid appending `Dir.pwd` to configuration file search paths in CLI tools. Only load configuration from secure, user-controlled locations like the user's home directory.

--- a/lib/zitadel_tui/config.rb
+++ b/lib/zitadel_tui/config.rb
@@ -20,7 +20,10 @@ module ZitadelTui
       @config.filename = 'zitadel-tui'
       @config.extname = '.yml'
       @config.append_path(Dir.home)
-      @config.append_path(Dir.pwd)
+      # SECURITY FIX: Removed @config.append_path(Dir.pwd)
+      # Loading configuration from the current working directory allows local attackers
+      # to easily override configuration settings if the tool is executed from an
+      # untrusted or shared directory (Local Configuration Hijacking).
 
       set_defaults
       load_config


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Local Configuration Hijacking. The configuration module loaded `.yml` files from the current working directory (`Dir.pwd`), meaning an attacker could drop a malicious configuration file in a shared directory (like `/tmp`). If a user executed the tool from that directory, their configuration would be hijacked.
🎯 Impact: Attackers could override critical settings, such as `zitadel_url`, redirecting authentication and API requests to an attacker-controlled server to steal service account credentials or PATs.
🔧 Fix: Removed `@config.append_path(Dir.pwd)` and documented the learning in the Sentinel journal and as an inline comment.
✅ Verification: Ran tests (`bundle exec rspec`) and linters to verify that no functional regressions were introduced.

---
*PR created automatically by Jules for task [455394230251753738](https://jules.google.com/task/455394230251753738) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/zitadel-tui/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
