### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure configuration loading

### DIFF
--- a/lib/zitadel_tui/config.rb
+++ b/lib/zitadel_tui/config.rb
@@ -20,7 +20,9 @@ module ZitadelTui
       @config.filename = 'zitadel-tui'
       @config.extname = '.yml'
       @config.append_path(Dir.home)
-      @config.append_path(Dir.pwd)
+      # SECURITY FIX: Do not load configuration from the current working directory.
+      # This prevents local attackers from overriding settings (e.g., redirecting
+      # URLs to steal credentials) if the tool is executed from an untrusted directory.
 
       set_defaults
       load_config

--- a/spec/examples.txt
+++ b/spec/examples.txt
@@ -1,20 +1,20 @@
 example_id                                 | status | run_time        |
 ------------------------------------------ | ------ | --------------- |
-./spec/zitadel_tui/client_spec.rb[1:1:1:1] | passed | 0.01666 seconds |
-./spec/zitadel_tui/config_spec.rb[1:1:1]   | passed | 0.00203 seconds |
-./spec/zitadel_tui/config_spec.rb[1:2:1]   | passed | 0.00059 seconds |
-./spec/zitadel_tui/config_spec.rb[1:2:2]   | passed | 0.00061 seconds |
-./spec/zitadel_tui/config_spec.rb[1:3:1]   | passed | 0.00193 seconds |
-./spec/zitadel_tui/config_spec.rb[1:4:1]   | passed | 0.00059 seconds |
-./spec/zitadel_tui/config_spec.rb[1:4:2]   | passed | 0.00066 seconds |
-./spec/zitadel_tui/config_spec.rb[1:4:3]   | passed | 0.0014 seconds  |
-./spec/zitadel_tui/config_spec.rb[1:5:1]   | passed | 0.0007 seconds  |
-./spec/zitadel_tui/config_spec.rb[1:5:2]   | passed | 0.00058 seconds |
-./spec/zitadel_tui/config_spec.rb[1:5:3]   | passed | 0.00285 seconds |
-./spec/zitadel_tui/ui_spec.rb[1:1:1]       | passed | 0.00029 seconds |
+./spec/zitadel_tui/client_spec.rb[1:1:1:1] | passed | 0.01672 seconds |
+./spec/zitadel_tui/config_spec.rb[1:1:1]   | passed | 0.00178 seconds |
+./spec/zitadel_tui/config_spec.rb[1:2:1]   | passed | 0.00032 seconds |
+./spec/zitadel_tui/config_spec.rb[1:2:2]   | passed | 0.00043 seconds |
+./spec/zitadel_tui/config_spec.rb[1:3:1]   | passed | 0.00029 seconds |
+./spec/zitadel_tui/config_spec.rb[1:4:1]   | passed | 0.0004 seconds  |
+./spec/zitadel_tui/config_spec.rb[1:4:2]   | passed | 0.00032 seconds |
+./spec/zitadel_tui/config_spec.rb[1:4:3]   | passed | 0.0012 seconds  |
+./spec/zitadel_tui/config_spec.rb[1:5:1]   | passed | 0.00043 seconds |
+./spec/zitadel_tui/config_spec.rb[1:5:2]   | passed | 0.0006 seconds  |
+./spec/zitadel_tui/config_spec.rb[1:5:3]   | passed | 0.0064 seconds  |
+./spec/zitadel_tui/ui_spec.rb[1:1:1]       | passed | 0.00027 seconds |
 ./spec/zitadel_tui/ui_spec.rb[1:1:2]       | passed | 0.0002 seconds  |
-./spec/zitadel_tui/ui_spec.rb[1:1:3]       | passed | 0.00079 seconds |
-./spec/zitadel_tui/ui_spec.rb[1:2:1]       | passed | 0.0002 seconds  |
-./spec/zitadel_tui/ui_spec.rb[1:3:1]       | passed | 0.00027 seconds |
-./spec/zitadel_tui/ui_spec.rb[1:4:1]       | passed | 0.00018 seconds |
-./spec/zitadel_tui/ui_spec.rb[1:5:1]       | passed | 0.00276 seconds |
+./spec/zitadel_tui/ui_spec.rb[1:1:3]       | passed | 0.00086 seconds |
+./spec/zitadel_tui/ui_spec.rb[1:2:1]       | passed | 0.00019 seconds |
+./spec/zitadel_tui/ui_spec.rb[1:3:1]       | passed | 0.00025 seconds |
+./spec/zitadel_tui/ui_spec.rb[1:4:1]       | passed | 0.00287 seconds |
+./spec/zitadel_tui/ui_spec.rb[1:5:1]       | passed | 0.00027 seconds |


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The application was explicitly appending the current working directory (`Dir.pwd`) to the configuration search paths. This allows local attackers to override configuration settings simply by planting a malicious `zitadel-tui.yml` file in a directory and tricking the user into running the tool from there.
🎯 Impact: An attacker could easily hijack the `zitadel_url` setting, redirecting all API requests and authentication workflows to a malicious server, thereby stealing sensitive tokens or credentials without the user realizing.
🔧 Fix: Removed `@config.append_path(Dir.pwd)` so the application defaults to loading trusted configuration from `Dir.home`. Added an inline comment explaining the security rationale.
✅ Verification: Ran `bundle exec rspec` and `bundle exec rubocop -A` to ensure functionality and syntax are intact. Validated no other occurrences of `Dir.pwd` exist in the configuration logic.

---
*PR created automatically by Jules for task [8223341329082103934](https://jules.google.com/task/8223341329082103934) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/zitadel-tui/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
