### PR TITLE
feat: add responsive TUI shell

### DIFF
--- a/src/tui/copy.rs
+++ b/src/tui/copy.rs
@@ -148,6 +148,7 @@ pub fn pending_label(pending: &PendingAction) -> &'static str {
     }
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn selection_title(app: &App) -> &'static str {
     match app.active_resource() {
         ResourceKind::Applications => "existing applications",
@@ -177,6 +178,7 @@ pub fn focus_label(focus: Focus) -> &'static str {
     }
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn status_mark(app: &App) -> &'static str {
     if app.setup_required {
         "!"

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -11,6 +11,7 @@ pub use copy::{focus_label, pending_label, resource_label, selection_title, stat
 pub use render::draw;
 #[allow(unused_imports)]
 pub use types::{
-    default_setup_form, Action, App, CanvasMode, ConfirmState, FieldKind, Focus, FormField,
-    FormState, MessageState, PendingAction, Record, Resource, ResourceKind, TuiBootstrap,
+    default_setup_form, Action, App, AppCommand, CanvasMode, ConfirmState, FieldKind, Focus,
+    FormField, FormState, MessageState, PendingAction, Record, Resource, ResourceKind,
+    TuiBootstrap,
 };

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -7,133 +7,233 @@ use ratatui::{
 };
 
 use super::{
-    copy::{footer_lines, selection_title},
-    types::{App, Focus},
-    widgets::{
-        bold_line, centered_rect, field_line, focus_border, list_item, muted_line, section_block,
-        title_span,
+    copy::{
+        browse_lines, browse_meta, browse_review_lines, browse_title, confirm_review_lines,
+        focus_label, footer_lines, form_review_lines, message_review_lines, resource_label,
     },
+    widgets::{bold_line, field_line, muted_line, render_form_line, status_heading},
+    App, CanvasMode, Focus,
 };
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ShellLayout {
+    Narrow,
+    Medium,
+    Wide,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CanvasTone {
+    Browse,
+    Form,
+    Setup,
+    Confirm,
+    Success,
+    Error,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PanelTone {
+    Info,
+    Warm,
+    Success,
+    Warning,
+    Error,
+    Muted,
+}
+
+#[derive(Debug)]
+pub(super) struct CanvasContent {
+    title: String,
+    meta: String,
+    lines: Vec<String>,
+    review_lines: Vec<Line<'static>>,
+    tone: CanvasTone,
+}
 
 pub fn draw(frame: &mut Frame, app: &App) {
     let area = frame.area();
-    let outer = Block::default().style(
-        Style::default()
-            .bg(Color::Rgb(16, 20, 29))
-            .fg(Color::Rgb(237, 243, 255)),
-    );
+    let layout_mode = shell_layout(area);
+    let outer = Block::default().style(Style::default().bg(shell_bg()).fg(foreground_color()));
     frame.render_widget(outer, area);
 
+    let header_height = shell_header_height(area, layout_mode);
+    let status_height = shell_status_height(area, layout_mode);
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),
-            Constraint::Min(10),
-            Constraint::Length(2),
+            Constraint::Length(header_height),
+            Constraint::Min(8),
+            Constraint::Length(status_height),
         ])
         .split(area);
 
-    draw_header(frame, layout[0], app);
-    draw_body(frame, layout[1], app);
-    draw_status(frame, layout[2], app);
+    draw_header(frame, layout[0], app, layout_mode);
+    draw_body(frame, layout[1], app, layout_mode);
+    draw_status(frame, layout[2], app, layout_mode);
 
     if app.show_inspector {
-        draw_inspector_popup(frame, centered_rect(38, 44, area), app);
+        draw_inspector_popup(frame, centered_rect(layout_mode, area), app);
     }
 }
 
-fn draw_header(frame: &mut Frame, area: Rect, app: &App) {
-    let header = Block::default().style(Style::default().bg(Color::Rgb(22, 30, 44)));
+fn draw_header(frame: &mut Frame, area: Rect, app: &App, layout_mode: ShellLayout) {
+    let header = Block::default().style(Style::default().bg(header_bg()));
     frame.render_widget(header, area);
 
-    let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(52), Constraint::Min(10)])
-        .split(area.inner(Margin {
-            horizontal: 2,
-            vertical: 1,
-        }));
+    let inner = inner_with_margin(area, 2, 1);
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
 
     let title = Paragraph::new(Line::from(vec![
         Span::styled(
             "ZITADEL TUI",
             Style::default()
-                .fg(Color::Rgb(145, 194, 255))
+                .fg(info_color())
                 .add_modifier(Modifier::BOLD),
         ),
         Span::raw("  "),
-        Span::styled(
-            "Command Atelier",
-            Style::default().fg(Color::Rgb(236, 156, 114)),
-        ),
+        Span::styled("Command Atelier", Style::default().fg(warm_color())),
     ]));
-    frame.render_widget(title, chunks[0]);
 
-    let auth_style = if app.setup_required {
-        Style::default()
-            .fg(Color::Rgb(245, 194, 66))
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default()
-            .fg(Color::Rgb(112, 224, 144))
-            .add_modifier(Modifier::BOLD)
+    let auth = Paragraph::new(auth_summary_line(app)).alignment(Alignment::Right);
+    let project = Paragraph::new(project_summary_line(app));
+    let host = Paragraph::new(host_summary_line(app))
+        .style(Style::default().fg(muted_color()))
+        .alignment(Alignment::Left);
+    let inspector = Paragraph::new(shortcut_line("[i]", "inspector")).alignment(Alignment::Right);
+
+    match layout_mode {
+        ShellLayout::Wide => {
+            let rows = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(1), Constraint::Length(1)])
+                .split(inner);
+            let top = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Min(24), Constraint::Length(30)])
+                .split(rows[0]);
+            let bottom = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([
+                    Constraint::Percentage(45),
+                    Constraint::Percentage(40),
+                    Constraint::Length(16),
+                ])
+                .split(rows[1]);
+
+            frame.render_widget(title, top[0]);
+            frame.render_widget(auth, top[1]);
+            frame.render_widget(project, bottom[0]);
+            frame.render_widget(host, bottom[1]);
+            frame.render_widget(inspector, bottom[2]);
+        }
+        ShellLayout::Medium => {
+            let rows = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(1), Constraint::Length(1)])
+                .split(inner);
+            let top = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Min(18), Constraint::Length(26)])
+                .split(rows[0]);
+            let bottom = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([
+                    Constraint::Percentage(40),
+                    Constraint::Percentage(45),
+                    Constraint::Length(16),
+                ])
+                .split(rows[1]);
+
+            frame.render_widget(title, top[0]);
+            frame.render_widget(auth, top[1]);
+            frame.render_widget(project, bottom[0]);
+            frame.render_widget(host, bottom[1]);
+            frame.render_widget(inspector, bottom[2]);
+        }
+        ShellLayout::Narrow => {
+            let rows = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(1),
+                    Constraint::Length(1),
+                    Constraint::Min(1),
+                ])
+                .split(inner);
+            let middle = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Min(16), Constraint::Length(18)])
+                .split(rows[1]);
+            let bottom = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Min(16), Constraint::Length(14)])
+                .split(rows[2]);
+
+            frame.render_widget(title, rows[0]);
+            frame.render_widget(project, middle[0]);
+            frame.render_widget(auth, middle[1]);
+            frame.render_widget(host, bottom[0]);
+            frame.render_widget(inspector, bottom[1]);
+        }
+    }
+}
+
+fn draw_body(frame: &mut Frame, area: Rect, app: &App, layout_mode: ShellLayout) {
+    let chunks = match layout_mode {
+        ShellLayout::Wide => Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Length(30), Constraint::Min(10)])
+            .split(area),
+        ShellLayout::Medium => Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Length(26), Constraint::Min(10)])
+            .split(area),
+        ShellLayout::Narrow => Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(19), Constraint::Min(10)])
+            .split(area),
     };
 
-    let right = Paragraph::new(Line::from(vec![
-        Span::styled(
-            format!("{} {}", app.auth_label, super::copy::status_mark(app)),
-            auth_style,
-        ),
-        Span::raw("   "),
-        Span::styled(
-            format!("project {}", app.project),
-            Style::default().fg(Color::Rgb(176, 188, 213)),
-        ),
-        Span::raw("   "),
-        Span::styled(
-            "[i] inspector",
-            Style::default().fg(Color::Rgb(145, 194, 255)),
-        ),
-    ]))
-    .alignment(Alignment::Right);
-    frame.render_widget(right, chunks[1]);
-
-    let host = Paragraph::new(app.host.clone())
-        .style(Style::default().fg(Color::Rgb(130, 140, 163)))
-        .alignment(Alignment::Right);
-    frame.render_widget(
-        host,
-        Rect::new(area.x + area.width.saturating_sub(34), area.y, 32, 1),
-    );
+    draw_command_rail(frame, chunks[0], app, layout_mode);
+    draw_workspace(frame, chunks[1], app, layout_mode);
 }
 
-fn draw_body(frame: &mut Frame, area: Rect, app: &App) {
-    let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(32), Constraint::Min(10)])
-        .split(area);
-    draw_command_rail(frame, chunks[0], app);
-    draw_workspace(frame, chunks[1], app);
-}
-
-fn draw_command_rail(frame: &mut Frame, area: Rect, app: &App) {
+fn draw_command_rail(frame: &mut Frame, area: Rect, app: &App, layout_mode: ShellLayout) {
     let rail = Block::default()
-        .borders(Borders::RIGHT)
-        .border_style(Style::default().fg(Color::Rgb(45, 56, 73)))
-        .style(Style::default().bg(Color::Rgb(15, 22, 33)));
+        .borders(match layout_mode {
+            ShellLayout::Narrow => Borders::BOTTOM,
+            ShellLayout::Medium | ShellLayout::Wide => Borders::RIGHT,
+        })
+        .border_style(Style::default().fg(border_color(false, PanelTone::Muted)))
+        .style(Style::default().bg(rail_bg()));
     frame.render_widget(rail, area);
 
-    let inner = area.inner(Margin {
-        horizontal: 2,
-        vertical: 1,
-    });
+    let inner = inner_with_margin(area, 2, 1);
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
     let sections = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Min(0),
-        ])
+        .constraints(match layout_mode {
+            ShellLayout::Wide => [
+                Constraint::Length(9),
+                Constraint::Length(8),
+                Constraint::Min(4),
+            ],
+            ShellLayout::Medium => [
+                Constraint::Length(8),
+                Constraint::Length(8),
+                Constraint::Min(4),
+            ],
+            ShellLayout::Narrow => [
+                Constraint::Length(7),
+                Constraint::Length(7),
+                Constraint::Min(3),
+            ],
+        })
         .split(inner);
 
     let resources: Vec<ListItem> = app
@@ -150,7 +250,12 @@ fn draw_command_rail(frame: &mut Frame, area: Rect, app: &App) {
         })
         .collect();
     frame.render_widget(
-        List::new(resources).block(section_block("Command rail", "[h/l] resource")),
+        List::new(resources).block(panel_block(
+            "Resources",
+            "[h/l] cycle",
+            PanelTone::Info,
+            app.focus == Focus::Resources,
+        )),
         sections[0],
     );
 
@@ -163,96 +268,107 @@ fn draw_command_rail(frame: &mut Frame, area: Rect, app: &App) {
                 item.label,
                 item.hotkey,
                 index == app.selected_action && app.focus == Focus::Actions,
-                Color::Rgb(236, 156, 114),
+                warm_color(),
             )
         })
         .collect();
     frame.render_widget(
-        List::new(actions).block(section_block("Actions", "[Enter] run")),
+        List::new(actions).block(panel_block(
+            "Actions",
+            "[j/k] choose  [Enter] run",
+            PanelTone::Warm,
+            app.focus == Focus::Actions,
+        )),
         sections[1],
     );
 
-    let footer = Paragraph::new(footer_lines(app))
+    let footer = Paragraph::new(guide_lines(app, layout_mode))
         .wrap(Wrap { trim: true })
-        .block(section_block("Status", ""));
+        .block(panel_block(
+            "Guide",
+            focused_hint(app),
+            PanelTone::Muted,
+            false,
+        ));
     frame.render_widget(footer, sections[2]);
 }
 
-fn draw_workspace(frame: &mut Frame, area: Rect, app: &App) {
-    let inner = area.inner(Margin {
-        horizontal: 2,
-        vertical: 1,
-    });
+fn draw_workspace(frame: &mut Frame, area: Rect, app: &App, layout_mode: ShellLayout) {
+    let inner = inner_with_margin(area, 2, 1);
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
     let sections = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(10), Constraint::Length(9)])
+        .constraints(match layout_mode {
+            ShellLayout::Wide => [Constraint::Min(10), Constraint::Length(9)],
+            ShellLayout::Medium => [Constraint::Min(11), Constraint::Length(8)],
+            ShellLayout::Narrow => [Constraint::Min(10), Constraint::Length(8)],
+        })
         .split(inner);
-    draw_canvas(frame, sections[0], app);
+    draw_canvas(frame, sections[0], app, layout_mode);
     draw_selection_tray(frame, sections[1], app);
 }
 
-fn draw_canvas(frame: &mut Frame, area: Rect, app: &App) {
-    let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(63), Constraint::Percentage(37)])
-        .split(area);
-    let canvas_title = app.canvas_title();
-    let canvas_meta = app.canvas_meta();
+fn draw_canvas(frame: &mut Frame, area: Rect, app: &App, layout_mode: ShellLayout) {
+    let chunks = match layout_mode {
+        ShellLayout::Wide => Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+            .split(area),
+        ShellLayout::Medium => Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(62), Constraint::Percentage(38)])
+            .split(area),
+        ShellLayout::Narrow => Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(58), Constraint::Percentage(42)])
+            .split(area),
+    };
+    let canvas = canvas_content(app);
 
-    let form_block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(focus_border(app.focus == Focus::Form))
-        .style(Style::default().bg(Color::Rgb(18, 26, 39)))
-        .title(title_span("Canvas", &canvas_title));
+    let form_block = panel_block(
+        &canvas.title,
+        &canvas.meta,
+        panel_tone(canvas.tone),
+        app.focus == Focus::Form,
+    );
     frame.render_widget(form_block, chunks[0]);
 
-    let form_lines = app.message_lines().join("\n");
-    let form = Paragraph::new(form_lines)
+    let form = Paragraph::new(canvas_body_lines(&canvas))
         .wrap(Wrap { trim: true })
         .alignment(Alignment::Left);
-    frame.render_widget(
-        form,
-        chunks[0].inner(Margin {
-            horizontal: 2,
-            vertical: 1,
-        }),
-    );
+    frame.render_widget(form, inner_with_margin(chunks[0], 2, 1));
 
-    let review_block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Rgb(47, 58, 79)))
-        .style(Style::default().bg(Color::Rgb(19, 27, 38)))
-        .title(title_span("Review", &canvas_meta));
+    let review_block = panel_block("Review", review_meta(canvas.tone), PanelTone::Muted, false);
     frame.render_widget(review_block, chunks[1]);
 
-    let review = Paragraph::new(app.review_lines()).wrap(Wrap { trim: true });
-    frame.render_widget(
-        review,
-        chunks[1].inner(Margin {
-            horizontal: 2,
-            vertical: 1,
-        }),
-    );
+    let review = Paragraph::new(canvas.review_lines).wrap(Wrap { trim: true });
+    frame.render_widget(review, inner_with_margin(chunks[1], 2, 1));
 }
 
 fn draw_selection_tray(frame: &mut Frame, area: Rect, app: &App) {
-    let tray = Block::default()
-        .borders(Borders::ALL)
-        .border_style(focus_border(app.focus == Focus::Records))
-        .style(Style::default().bg(Color::Rgb(18, 26, 39)))
-        .title(title_span("Selection tray", selection_title(app)));
+    let tray = panel_block(
+        "Selection tray",
+        selection_meta(app),
+        PanelTone::Info,
+        app.focus == Focus::Records,
+    );
     frame.render_widget(tray, area);
 
     if app.active_records().is_empty() {
-        let empty = Paragraph::new("No records loaded for this resource.")
-            .style(Style::default().fg(Color::Rgb(121, 131, 151)));
-        frame.render_widget(
-            empty,
-            area.inner(Margin {
-                horizontal: 2,
-                vertical: 1,
-            }),
-        );
+        let empty = Paragraph::new(vec![
+            Line::from(Span::styled(
+                "No records loaded yet.",
+                Style::default()
+                    .fg(subtle_color())
+                    .add_modifier(Modifier::BOLD),
+            )),
+            muted_line("This tray updates after refreshes and completed workflows."),
+            muted_line("Use the resource rail to switch context or run an action."),
+        ]);
+        frame.render_widget(empty, inner_with_margin(area, 2, 1));
         return;
     }
 
@@ -269,49 +385,29 @@ fn draw_selection_tray(frame: &mut Frame, area: Rect, app: &App) {
             )
         })
         .collect();
-    frame.render_widget(
-        List::new(rows),
-        area.inner(Margin {
-            horizontal: 2,
-            vertical: 1,
-        }),
-    );
+    frame.render_widget(List::new(rows), inner_with_margin(area, 2, 1));
 }
 
-fn draw_status(frame: &mut Frame, area: Rect, app: &App) {
+fn draw_status(frame: &mut Frame, area: Rect, app: &App, layout_mode: ShellLayout) {
     let status = Block::default()
-        .style(Style::default().bg(Color::Rgb(12, 18, 29)))
+        .style(Style::default().bg(status_bg()))
         .borders(Borders::TOP)
-        .border_style(Style::default().fg(Color::Rgb(45, 56, 73)));
+        .border_style(Style::default().fg(border_color(false, PanelTone::Muted)));
     frame.render_widget(status, area);
 
-    let selected = app
-        .selected_record()
-        .map(|record| record.name.as_str())
-        .unwrap_or("none");
-    let text = format!(
-        "{}. [Tab] focus  [Enter] act  [Esc] back  [j/k] move  [i] inspector  Selected: {}",
-        super::copy::resource_label(app.active_resource()),
-        selected
-    );
     frame.render_widget(
-        Paragraph::new(text)
-            .style(Style::default().fg(Color::Rgb(130, 140, 163)))
+        Paragraph::new(status_lines(app, layout_mode))
+            .style(Style::default().fg(muted_color()))
+            .wrap(Wrap { trim: true })
             .alignment(Alignment::Left),
-        area.inner(Margin {
-            horizontal: 2,
-            vertical: 0,
-        }),
+        inner_with_margin(area, 2, 0),
     );
 }
 
 fn draw_inspector_popup(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(Clear, area);
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Rgb(145, 194, 255)))
-        .style(Style::default().bg(Color::Rgb(10, 14, 22)))
-        .title(title_span("Inspector popup", "[i] close"));
+    let block = panel_block("Inspector", "[i] close", PanelTone::Info, true)
+        .style(Style::default().bg(popup_bg()));
     frame.render_widget(block, area);
 
     let lines = if let Some(record) = app.selected_record() {
@@ -331,11 +427,538 @@ fn draw_inspector_popup(frame: &mut Frame, area: Rect, app: &App) {
     };
 
     let text = Paragraph::new(lines).wrap(Wrap { trim: true });
-    frame.render_widget(
-        text,
-        area.inner(Margin {
-            horizontal: 2,
-            vertical: 1,
-        }),
-    );
+    frame.render_widget(text, inner_with_margin(area, 2, 1));
+}
+
+fn shell_layout(area: Rect) -> ShellLayout {
+    if area.width < 96 {
+        ShellLayout::Narrow
+    } else if area.width < 140 {
+        ShellLayout::Medium
+    } else {
+        ShellLayout::Wide
+    }
+}
+
+fn shell_header_height(area: Rect, layout_mode: ShellLayout) -> u16 {
+    if area.height < 12 {
+        3
+    } else {
+        match layout_mode {
+            ShellLayout::Narrow => 5,
+            ShellLayout::Medium | ShellLayout::Wide => 4,
+        }
+    }
+}
+
+fn shell_status_height(area: Rect, layout_mode: ShellLayout) -> u16 {
+    if area.height < 10 {
+        1
+    } else {
+        match layout_mode {
+            ShellLayout::Narrow => 3,
+            ShellLayout::Medium | ShellLayout::Wide => 2,
+        }
+    }
+}
+
+pub(super) fn canvas_content(app: &App) -> CanvasContent {
+    match &app.canvas_mode {
+        CanvasMode::Browse => CanvasContent {
+            title: browse_title(app).to_string(),
+            meta: browse_meta(app).to_string(),
+            lines: browse_lines(app),
+            review_lines: browse_review_lines(app),
+            tone: CanvasTone::Browse,
+        },
+        CanvasMode::EditForm(form) => CanvasContent {
+            title: form.title.clone(),
+            meta: form.submit_label.clone(),
+            lines: form
+                .fields
+                .iter()
+                .enumerate()
+                .map(|(index, field)| render_form_line(field, index == form.selected_field))
+                .collect(),
+            review_lines: form_review_lines(form),
+            tone: CanvasTone::Form,
+        },
+        CanvasMode::Setup(form) => CanvasContent {
+            title: form.title.clone(),
+            meta: form.submit_label.clone(),
+            lines: form
+                .fields
+                .iter()
+                .enumerate()
+                .map(|(index, field)| render_form_line(field, index == form.selected_field))
+                .collect(),
+            review_lines: form_review_lines(form),
+            tone: CanvasTone::Setup,
+        },
+        CanvasMode::Confirm(confirm) => CanvasContent {
+            title: confirm.title.clone(),
+            meta: confirm.submit_label.clone(),
+            lines: confirm.lines.clone(),
+            review_lines: confirm_review_lines(confirm),
+            tone: CanvasTone::Confirm,
+        },
+        CanvasMode::Success(message) => CanvasContent {
+            title: message.title.clone(),
+            meta: "[Enter] continue".to_string(),
+            lines: message.lines.clone(),
+            review_lines: message_review_lines(message),
+            tone: CanvasTone::Success,
+        },
+        CanvasMode::Error(message) => CanvasContent {
+            title: message.title.clone(),
+            meta: "[Esc] back".to_string(),
+            lines: message.lines.clone(),
+            review_lines: message_review_lines(message),
+            tone: CanvasTone::Error,
+        },
+    }
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+pub(super) fn canvas_title(app: &App) -> String {
+    canvas_content(app).title
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+pub(super) fn canvas_lines(app: &App) -> Vec<String> {
+    canvas_content(app).lines
+}
+
+fn canvas_body_lines(canvas: &CanvasContent) -> Vec<Line<'static>> {
+    let mut lines = match canvas.tone {
+        CanvasTone::Browse => Vec::new(),
+        CanvasTone::Form => vec![highlight_line(
+            "● Edit fields and submit when ready.",
+            info_color(),
+        )],
+        CanvasTone::Setup => vec![highlight_line(
+            "⚠ Setup is required before the main workspace can run actions.",
+            warning_color(),
+        )],
+        CanvasTone::Confirm => vec![highlight_line(
+            "● Confirm the pending action or cancel to return safely.",
+            warm_color(),
+        )],
+        CanvasTone::Success => vec![highlight_line("✓ Workflow completed.", success_color())],
+        CanvasTone::Error => vec![highlight_line(
+            "⚠ Workflow needs attention before continuing.",
+            error_color(),
+        )],
+    };
+
+    if !lines.is_empty() {
+        lines.push(Line::from(""));
+    }
+
+    lines.extend(canvas.lines.iter().enumerate().map(|(index, line)| {
+        let style = if index == 0 && matches!(canvas.tone, CanvasTone::Browse) {
+            Style::default()
+                .fg(subtle_color())
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(foreground_color())
+        };
+        Line::from(Span::styled(line.clone(), style))
+    }));
+    lines
+}
+
+fn review_meta(tone: CanvasTone) -> &'static str {
+    match tone {
+        CanvasTone::Browse => "selection context",
+        CanvasTone::Form | CanvasTone::Setup => "field summary",
+        CanvasTone::Confirm => "pending action",
+        CanvasTone::Success | CanvasTone::Error => "workflow result",
+    }
+}
+
+fn selection_meta(app: &App) -> &'static str {
+    if app.active_records().is_empty() {
+        "waiting for records"
+    } else {
+        "[j/k] move  [i] inspect"
+    }
+}
+
+fn guide_lines(app: &App, layout_mode: ShellLayout) -> Vec<Line<'static>> {
+    let mut lines = vec![status_heading(match app.focus {
+        Focus::Resources => "Resource rail",
+        Focus::Actions => "Action rail",
+        Focus::Form => "Canvas",
+        Focus::Records => "Selection tray",
+    })];
+
+    match app.focus {
+        Focus::Resources => lines.push(shortcut_line("[h/l]", "change resource")),
+        Focus::Actions => {
+            lines.push(shortcut_line("[j/k]", "choose action"));
+            lines.push(shortcut_line("[Enter]", "run selected action"));
+        }
+        Focus::Form => match &app.canvas_mode {
+            CanvasMode::Browse => lines.push(shortcut_line("[Enter]", "begin selected action")),
+            CanvasMode::EditForm(_) | CanvasMode::Setup(_) => {
+                lines.push(shortcut_line("[j/k]", "move fields"));
+                lines.push(shortcut_line("[Space]", "toggle or cycle choices"));
+            }
+            CanvasMode::Confirm(_) => lines.push(shortcut_line("[Enter]", "confirm action")),
+            CanvasMode::Success(_) | CanvasMode::Error(_) => {
+                lines.push(shortcut_line("[Enter]", "return to workspace"))
+            }
+        },
+        Focus::Records => {
+            lines.push(shortcut_line("[j/k]", "move record"));
+            lines.push(shortcut_line("[i]", "inspect selected record"));
+        }
+    }
+
+    if matches!(layout_mode, ShellLayout::Wide) {
+        lines.push(Line::from(""));
+        lines.extend(footer_lines(app));
+    } else if let Some(summary) = footer_lines(app).into_iter().nth(1) {
+        lines.push(Line::from(""));
+        lines.push(summary);
+    }
+
+    lines
+}
+
+fn focused_hint(app: &App) -> &'static str {
+    match app.focus {
+        Focus::Resources => "resource focus",
+        Focus::Actions => "action focus",
+        Focus::Form => "canvas focus",
+        Focus::Records => "record focus",
+    }
+}
+
+fn status_lines(app: &App, layout_mode: ShellLayout) -> Vec<Line<'static>> {
+    let selected = app
+        .selected_record()
+        .map(|record| record.name.as_str())
+        .unwrap_or("none");
+
+    let summary = Line::from(vec![
+        Span::styled(
+            resource_label(app.active_resource()).to_string(),
+            Style::default()
+                .fg(info_color())
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("  •  ", Style::default().fg(muted_color())),
+        Span::styled(
+            format!("focus {}", focus_label(app.focus)),
+            Style::default().fg(subtle_color()),
+        ),
+        Span::styled("  •  ", Style::default().fg(muted_color())),
+        Span::styled(
+            format!("selected {selected}"),
+            Style::default().fg(foreground_color()),
+        ),
+    ]);
+
+    let primary_help = match layout_mode {
+        ShellLayout::Wide | ShellLayout::Medium => Line::from(vec![
+            shortcut_span("[Tab]"),
+            muted_span(" focus  "),
+            shortcut_span("[Esc]"),
+            muted_span(" back  "),
+            shortcut_span("[q]"),
+            muted_span(" quit  "),
+            shortcut_span("[i]"),
+            muted_span(" inspector"),
+        ]),
+        ShellLayout::Narrow => Line::from(vec![
+            shortcut_span("[Tab]"),
+            muted_span(" focus  "),
+            shortcut_span("[Enter]"),
+            muted_span(" act  "),
+            shortcut_span("[Esc]"),
+            muted_span(" back"),
+        ]),
+    };
+
+    if matches!(layout_mode, ShellLayout::Narrow) {
+        vec![
+            summary,
+            primary_help,
+            Line::from(vec![
+                shortcut_span("[j/k]"),
+                muted_span(" move  "),
+                shortcut_span("[h/l]"),
+                muted_span(" resource"),
+            ]),
+        ]
+    } else {
+        vec![summary, primary_help]
+    }
+}
+
+fn auth_summary_line(app: &App) -> Line<'static> {
+    let (status_text, color) = if app.setup_required {
+        ("⚠ setup required", warning_color())
+    } else {
+        ("✓ ready", success_color())
+    };
+
+    Line::from(vec![
+        Span::styled(
+            app.auth_label.clone(),
+            Style::default()
+                .fg(subtle_color())
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            status_text.to_string(),
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ),
+    ])
+}
+
+fn project_summary_line(app: &App) -> Line<'static> {
+    let project = if app.project.is_empty() {
+        "auto".to_string()
+    } else {
+        app.project.clone()
+    };
+    Line::from(vec![
+        Span::styled("project", Style::default().fg(muted_color())),
+        Span::raw(" "),
+        Span::styled(project, Style::default().fg(subtle_color())),
+    ])
+}
+
+fn host_summary_line(app: &App) -> Line<'static> {
+    Line::from(vec![
+        Span::styled("host", Style::default().fg(muted_color())),
+        Span::raw(" "),
+        Span::styled(app.host.clone(), Style::default().fg(subtle_color())),
+    ])
+}
+
+fn shortcut_line(key: &str, label: &str) -> Line<'static> {
+    Line::from(vec![shortcut_span(key), muted_span(format!(" {label}"))])
+}
+
+fn shortcut_span(value: &str) -> Span<'static> {
+    Span::styled(
+        value.to_string(),
+        Style::default()
+            .fg(info_color())
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+fn muted_span(value: impl Into<String>) -> Span<'static> {
+    Span::styled(value.into(), Style::default().fg(muted_color()))
+}
+
+fn highlight_line(value: &str, color: Color) -> Line<'static> {
+    Line::from(Span::styled(
+        value.to_string(),
+        Style::default().fg(color).add_modifier(Modifier::BOLD),
+    ))
+}
+
+fn panel_tone(tone: CanvasTone) -> PanelTone {
+    match tone {
+        CanvasTone::Browse => PanelTone::Info,
+        CanvasTone::Form => PanelTone::Warm,
+        CanvasTone::Setup => PanelTone::Warning,
+        CanvasTone::Confirm => PanelTone::Warm,
+        CanvasTone::Success => PanelTone::Success,
+        CanvasTone::Error => PanelTone::Error,
+    }
+}
+
+fn list_item(label: &str, meta: &str, selected: bool, accent: Color) -> ListItem<'static> {
+    let style = if selected {
+        Style::default()
+            .bg(accent_surface(accent))
+            .fg(foreground_color())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Rgb(210, 219, 239))
+    };
+    let mut spans = vec![Span::styled(label.to_string(), style)];
+    if !meta.is_empty() {
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(meta.to_string(), Style::default().fg(accent)));
+    }
+    ListItem::new(Line::from(spans))
+}
+
+fn panel_block<'a>(title: &'a str, meta: &'a str, tone: PanelTone, focused: bool) -> Block<'a> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color(focused, tone)))
+        .style(Style::default().bg(panel_bg(tone)))
+        .title(title_span(title, meta, tone, focused))
+}
+
+fn title_span<'a>(title: &'a str, meta: &'a str, tone: PanelTone, focused: bool) -> Line<'a> {
+    let mut spans = vec![Span::styled(
+        title,
+        Style::default()
+            .fg(title_color(tone, focused))
+            .add_modifier(Modifier::BOLD),
+    )];
+    if !meta.is_empty() {
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(meta, Style::default().fg(muted_color())));
+    }
+    Line::from(spans)
+}
+
+fn centered_rect(layout_mode: ShellLayout, area: Rect) -> Rect {
+    let preferred_width = match layout_mode {
+        ShellLayout::Wide => 76,
+        ShellLayout::Medium => 64,
+        ShellLayout::Narrow => 48,
+    };
+    let preferred_height = match layout_mode {
+        ShellLayout::Wide => 18,
+        ShellLayout::Medium => 16,
+        ShellLayout::Narrow => 12,
+    };
+
+    let horizontal_padding = if area.width > 20 { 2 } else { 1 };
+    let vertical_padding = if area.height > 10 { 1 } else { 0 };
+    let width = clamp_popup_dimension(area.width, preferred_width, 28, horizontal_padding);
+    let height = clamp_popup_dimension(area.height, preferred_height, 8, vertical_padding);
+
+    Rect::new(
+        area.x + area.width.saturating_sub(width) / 2,
+        area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    )
+}
+
+fn clamp_popup_dimension(total: u16, preferred: u16, minimum: u16, padding: u16) -> u16 {
+    let max_available = total.saturating_sub(padding.saturating_mul(2)).max(1);
+    preferred
+        .min(max_available)
+        .max(total.min(minimum).max(1))
+        .min(total)
+}
+
+fn inner_with_margin(area: Rect, horizontal: u16, vertical: u16) -> Rect {
+    area.inner(Margin {
+        horizontal: horizontal.min(area.width / 2),
+        vertical: vertical.min(area.height / 2),
+    })
+}
+
+fn shell_bg() -> Color {
+    Color::Rgb(14, 19, 27)
+}
+
+fn header_bg() -> Color {
+    Color::Rgb(20, 28, 41)
+}
+
+fn rail_bg() -> Color {
+    Color::Rgb(16, 22, 33)
+}
+
+fn status_bg() -> Color {
+    Color::Rgb(11, 16, 25)
+}
+
+fn popup_bg() -> Color {
+    Color::Rgb(9, 13, 20)
+}
+
+fn panel_bg(tone: PanelTone) -> Color {
+    match tone {
+        PanelTone::Info => Color::Rgb(18, 27, 40),
+        PanelTone::Warm => Color::Rgb(23, 26, 37),
+        PanelTone::Success => Color::Rgb(18, 31, 28),
+        PanelTone::Warning => Color::Rgb(35, 30, 18),
+        PanelTone::Error => Color::Rgb(39, 21, 24),
+        PanelTone::Muted => Color::Rgb(17, 24, 35),
+    }
+}
+
+fn border_color(focused: bool, tone: PanelTone) -> Color {
+    if focused {
+        match tone {
+            PanelTone::Info => info_color(),
+            PanelTone::Warm => warm_color(),
+            PanelTone::Success => success_color(),
+            PanelTone::Warning => warning_color(),
+            PanelTone::Error => error_color(),
+            PanelTone::Muted => subtle_color(),
+        }
+    } else {
+        match tone {
+            PanelTone::Info => Color::Rgb(53, 72, 97),
+            PanelTone::Warm => Color::Rgb(88, 67, 58),
+            PanelTone::Success => Color::Rgb(44, 90, 71),
+            PanelTone::Warning => Color::Rgb(107, 89, 44),
+            PanelTone::Error => Color::Rgb(113, 64, 69),
+            PanelTone::Muted => Color::Rgb(45, 56, 73),
+        }
+    }
+}
+
+fn title_color(tone: PanelTone, focused: bool) -> Color {
+    if focused {
+        border_color(true, tone)
+    } else {
+        match tone {
+            PanelTone::Info => subtle_color(),
+            PanelTone::Warm => Color::Rgb(224, 178, 147),
+            PanelTone::Success => success_color(),
+            PanelTone::Warning => warning_color(),
+            PanelTone::Error => error_color(),
+            PanelTone::Muted => subtle_color(),
+        }
+    }
+}
+
+fn accent_surface(accent: Color) -> Color {
+    match accent {
+        Color::Rgb(236, 156, 114) => Color::Rgb(68, 43, 33),
+        Color::Rgb(112, 224, 144) => Color::Rgb(26, 58, 44),
+        _ => Color::Rgb(31, 48, 76),
+    }
+}
+
+fn foreground_color() -> Color {
+    Color::Rgb(237, 243, 255)
+}
+
+fn subtle_color() -> Color {
+    Color::Rgb(176, 188, 213)
+}
+
+fn muted_color() -> Color {
+    Color::Rgb(121, 131, 151)
+}
+
+fn info_color() -> Color {
+    Color::Rgb(145, 194, 255)
+}
+
+fn warm_color() -> Color {
+    Color::Rgb(236, 156, 114)
+}
+
+fn success_color() -> Color {
+    Color::Rgb(112, 224, 144)
+}
+
+fn warning_color() -> Color {
+    Color::Rgb(245, 194, 66)
+}
+
+fn error_color() -> Color {
+    Color::Rgb(242, 117, 121)
 }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1,14 +1,9 @@
-use ratatui::text::Line;
+use crossterm::event::KeyCode;
 
-use super::{
-    copy::{
-        browse_lines, browse_meta, browse_review_lines, browse_title, confirm_review_lines,
-        form_review_lines, message_review_lines,
-    },
-    types::{
-        default_setup_form, App, CanvasMode, Focus, FormField, FormState, Resource, ResourceKind,
-        TuiBootstrap, APPLICATION_ACTIONS, AUTH_ACTIONS, CONFIG_ACTIONS, IDP_ACTIONS, USER_ACTIONS,
-    },
+use super::types::{
+    default_setup_form, App, AppCommand, CanvasMode, Focus, FormField, FormState, Resource,
+    ResourceKind, TuiBootstrap, APPLICATION_ACTIONS, AUTH_ACTIONS, CONFIG_ACTIONS, IDP_ACTIONS,
+    USER_ACTIONS,
 };
 
 impl App {
@@ -206,31 +201,83 @@ impl App {
         self.show_inspector = !self.show_inspector;
     }
 
+    pub fn handle_key(&mut self, key: KeyCode) -> AppCommand {
+        match key {
+            KeyCode::Char('q') => AppCommand::Quit,
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.move_forward();
+                AppCommand::Noop
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.move_backward();
+                AppCommand::Noop
+            }
+            KeyCode::Char('h') | KeyCode::Left => {
+                self.move_left();
+                AppCommand::Noop
+            }
+            KeyCode::Char('l') | KeyCode::Right => {
+                self.move_right();
+                AppCommand::Noop
+            }
+            KeyCode::Char('i') => {
+                self.toggle_inspector();
+                AppCommand::Noop
+            }
+            KeyCode::Char('n') => {
+                self.set_focus(Focus::Actions);
+                AppCommand::Noop
+            }
+            KeyCode::Char('g') => {
+                self.set_focus(Focus::Resources);
+                AppCommand::Noop
+            }
+            KeyCode::Enter => self.handle_enter(),
+            KeyCode::Esc => {
+                self.handle_escape();
+                AppCommand::Noop
+            }
+            KeyCode::Backspace => {
+                if self.is_form_editing() {
+                    self.form_backspace();
+                }
+                AppCommand::Noop
+            }
+            KeyCode::Char(' ') => {
+                if self.is_form_editing() {
+                    self.form_toggle_or_cycle(true);
+                }
+                AppCommand::Noop
+            }
+            KeyCode::Char(ch) => {
+                if self.is_form_editing() {
+                    self.form_insert_char(ch);
+                }
+                AppCommand::Noop
+            }
+            KeyCode::Tab => {
+                self.advance_focus();
+                AppCommand::Noop
+            }
+            KeyCode::BackTab => {
+                self.reverse_focus();
+                AppCommand::Noop
+            }
+            _ => AppCommand::Noop,
+        }
+    }
+
     pub fn advance_focus(&mut self) {
-        self.focus = match self.focus {
-            Focus::Resources => Focus::Actions,
-            Focus::Actions => Focus::Form,
-            Focus::Form => Focus::Records,
-            Focus::Records => Focus::Resources,
-        };
+        self.cycle_focus(true);
     }
 
     pub fn reverse_focus(&mut self) {
-        self.focus = match self.focus {
-            Focus::Resources => Focus::Records,
-            Focus::Actions => Focus::Resources,
-            Focus::Form => Focus::Actions,
-            Focus::Records => Focus::Form,
-        };
+        self.cycle_focus(false);
     }
 
     pub fn set_canvas_mode(&mut self, canvas_mode: CanvasMode) {
         self.canvas_mode = canvas_mode;
-        self.focus = match self.canvas_mode {
-            CanvasMode::Browse => Focus::Resources,
-            CanvasMode::EditForm(_) | CanvasMode::Setup(_) => Focus::Form,
-            CanvasMode::Confirm(_) | CanvasMode::Success(_) | CanvasMode::Error(_) => Focus::Form,
-        };
+        self.focus = self.focus_order()[0];
     }
 
     pub fn reset_to_browse(&mut self) {
@@ -314,52 +361,6 @@ impl App {
         }
     }
 
-    pub fn message_lines(&self) -> Vec<String> {
-        match &self.canvas_mode {
-            CanvasMode::Browse => browse_lines(self),
-            CanvasMode::EditForm(form) | CanvasMode::Setup(form) => form
-                .fields
-                .iter()
-                .enumerate()
-                .map(|(index, field)| {
-                    super::widgets::render_form_line(field, index == form.selected_field)
-                })
-                .collect(),
-            CanvasMode::Confirm(confirm) => confirm.lines.clone(),
-            CanvasMode::Success(message) | CanvasMode::Error(message) => message.lines.clone(),
-        }
-    }
-
-    pub fn canvas_title(&self) -> String {
-        match &self.canvas_mode {
-            CanvasMode::Browse => browse_title(self).to_string(),
-            CanvasMode::EditForm(form) | CanvasMode::Setup(form) => form.title.clone(),
-            CanvasMode::Confirm(confirm) => confirm.title.clone(),
-            CanvasMode::Success(message) | CanvasMode::Error(message) => message.title.clone(),
-        }
-    }
-
-    pub fn canvas_meta(&self) -> String {
-        match &self.canvas_mode {
-            CanvasMode::Browse => browse_meta(self).to_string(),
-            CanvasMode::EditForm(form) | CanvasMode::Setup(form) => form.submit_label.clone(),
-            CanvasMode::Confirm(confirm) => confirm.submit_label.clone(),
-            CanvasMode::Success(_) => "[Enter] continue".to_string(),
-            CanvasMode::Error(_) => "[Esc] back".to_string(),
-        }
-    }
-
-    pub fn review_lines(&self) -> Vec<Line<'static>> {
-        match &self.canvas_mode {
-            CanvasMode::Browse => browse_review_lines(self),
-            CanvasMode::EditForm(form) | CanvasMode::Setup(form) => form_review_lines(form),
-            CanvasMode::Confirm(confirm) => confirm_review_lines(confirm),
-            CanvasMode::Success(message) | CanvasMode::Error(message) => {
-                message_review_lines(message)
-            }
-        }
-    }
-
     fn form_state_mut(&mut self) -> Option<&mut FormState> {
         match &mut self.canvas_mode {
             CanvasMode::EditForm(form) | CanvasMode::Setup(form) => Some(form),
@@ -373,6 +374,114 @@ impl App {
     fn active_form_field_mut(&mut self) -> Option<&mut FormField> {
         self.form_state_mut()
             .and_then(|form| form.fields.get_mut(form.selected_field))
+    }
+
+    fn move_forward(&mut self) {
+        match self.focus {
+            Focus::Resources => self.next_resource(),
+            Focus::Actions => self.next_action(),
+            Focus::Form => self.form_next_field(),
+            Focus::Records => self.next_record(),
+        }
+    }
+
+    fn move_backward(&mut self) {
+        match self.focus {
+            Focus::Resources => self.previous_resource(),
+            Focus::Actions => self.previous_action(),
+            Focus::Form => self.form_previous_field(),
+            Focus::Records => self.previous_record(),
+        }
+    }
+
+    fn move_left(&mut self) {
+        if self.is_form_editing() {
+            self.form_toggle_or_cycle(false);
+            return;
+        }
+
+        if self.focus != Focus::Form {
+            self.previous_resource();
+        }
+    }
+
+    fn move_right(&mut self) {
+        if self.is_form_editing() {
+            self.form_toggle_or_cycle(true);
+            return;
+        }
+
+        if self.focus != Focus::Form {
+            self.next_resource();
+        }
+    }
+
+    fn handle_enter(&mut self) -> AppCommand {
+        match &self.canvas_mode {
+            CanvasMode::Browse => AppCommand::BeginAction {
+                resource: self.active_resource(),
+                action_index: self.selected_action,
+                selected_record: self.selected_record().cloned(),
+            },
+            CanvasMode::EditForm(form) | CanvasMode::Setup(form) => {
+                AppCommand::SubmitForm(form.clone())
+            }
+            CanvasMode::Confirm(confirm) => AppCommand::Confirm(confirm.pending.clone()),
+            CanvasMode::Success(_) | CanvasMode::Error(_) => {
+                self.reset_to_browse();
+                AppCommand::Noop
+            }
+        }
+    }
+
+    fn handle_escape(&mut self) {
+        if !matches!(self.canvas_mode, CanvasMode::Browse) {
+            self.reset_to_browse();
+        }
+    }
+
+    fn is_form_editing(&self) -> bool {
+        self.focus == Focus::Form
+            && matches!(
+                self.canvas_mode,
+                CanvasMode::EditForm(_) | CanvasMode::Setup(_)
+            )
+    }
+
+    fn cycle_focus(&mut self, forward: bool) {
+        let ring = self.focus_order();
+        let current_index = ring
+            .iter()
+            .position(|focus| *focus == self.focus)
+            .unwrap_or(0);
+        let next_index = if forward {
+            (current_index + 1) % ring.len()
+        } else if current_index == 0 {
+            ring.len() - 1
+        } else {
+            current_index - 1
+        };
+        self.focus = ring[next_index];
+    }
+
+    fn set_focus(&mut self, focus: Focus) {
+        if self.focus_order().contains(&focus) {
+            self.focus = focus;
+        }
+    }
+
+    fn focus_order(&self) -> Vec<Focus> {
+        let mut order = if matches!(self.canvas_mode, CanvasMode::Browse) {
+            vec![Focus::Resources, Focus::Actions]
+        } else {
+            vec![Focus::Form, Focus::Resources, Focus::Actions]
+        };
+
+        if !self.active_records().is_empty() {
+            order.push(Focus::Records);
+        }
+
+        order
     }
 }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1,9 +1,10 @@
 use super::{
     copy::{focus_label, pending_label, resource_label, selection_title, status_mark},
+    render::{canvas_lines, canvas_title},
     state::{cycle_choice, is_enabled, toggle_field},
     types::{
-        default_setup_form, App, CanvasMode, FieldKind, Focus, FormField, FormState, MessageState,
-        PendingAction, Record, ResourceKind, TuiBootstrap,
+        default_setup_form, App, AppCommand, CanvasMode, FieldKind, Focus, FormField, FormState,
+        MessageState, PendingAction, Record, ResourceKind, TuiBootstrap,
     },
     widgets::render_form_line,
 };
@@ -26,10 +27,6 @@ fn focus_cycles_forward() {
     let mut app = test_app();
     app.advance_focus();
     assert_eq!(app.focus, Focus::Actions);
-    app.advance_focus();
-    assert_eq!(app.focus, Focus::Form);
-    app.advance_focus();
-    assert_eq!(app.focus, Focus::Records);
     app.advance_focus();
     assert_eq!(app.focus, Focus::Resources);
 }
@@ -55,14 +52,70 @@ fn action_navigation_tracks_current_resource() {
 }
 
 #[test]
+fn enter_in_browse_mode_returns_begin_action_command() {
+    let mut app = test_app();
+    assert_eq!(
+        app.handle_key(crossterm::event::KeyCode::Enter),
+        AppCommand::BeginAction {
+            resource: ResourceKind::Applications,
+            action_index: 0,
+            selected_record: None,
+        }
+    );
+}
+
+#[test]
 fn focus_cycles_backward() {
     let mut app = test_app();
     app.reverse_focus();
-    assert_eq!(app.focus, Focus::Records);
-    app.reverse_focus();
-    assert_eq!(app.focus, Focus::Form);
-    app.reverse_focus();
     assert_eq!(app.focus, Focus::Actions);
+    app.reverse_focus();
+    assert_eq!(app.focus, Focus::Resources);
+}
+
+#[test]
+fn focus_cycles_form_first_when_modal_is_open() {
+    let mut app = App::from_bootstrap(TuiBootstrap {
+        host: "https://zitadel.example.com".to_string(),
+        project: "core".to_string(),
+        auth_label: "PAT".to_string(),
+        templates_path: None,
+        setup_required: false,
+        app_records: vec![Record {
+            id: "app-1".to_string(),
+            name: "grafana".to_string(),
+            kind: "public".to_string(),
+            summary: String::new(),
+            detail: String::new(),
+            changed_at: String::new(),
+        }],
+        user_records: vec![],
+        idp_records: vec![],
+    });
+    app.set_canvas_mode(CanvasMode::EditForm(FormState {
+        title: "Edit".to_string(),
+        description: String::new(),
+        submit_label: String::new(),
+        fields: vec![FormField {
+            key: "name",
+            label: "Name".to_string(),
+            value: String::new(),
+            kind: FieldKind::Text,
+            help: String::new(),
+        }],
+        selected_field: 0,
+        pending: PendingAction::SaveConfig,
+    }));
+
+    assert_eq!(app.focus, Focus::Form);
+    app.advance_focus();
+    assert_eq!(app.focus, Focus::Resources);
+    app.advance_focus();
+    assert_eq!(app.focus, Focus::Actions);
+    app.advance_focus();
+    assert_eq!(app.focus, Focus::Records);
+    app.advance_focus();
+    assert_eq!(app.focus, Focus::Form);
 }
 
 #[test]
@@ -698,7 +751,7 @@ fn set_canvas_mode_browse_sets_focus_to_resources() {
 #[test]
 fn canvas_title_browse_mode() {
     let app = test_app();
-    let title = app.canvas_title();
+    let title = canvas_title(&app);
     assert!(!title.is_empty());
 }
 
@@ -709,7 +762,7 @@ fn canvas_title_error_mode() {
         title: "Something failed".to_string(),
         lines: vec!["detail".to_string()],
     }));
-    assert_eq!(app.canvas_title(), "Something failed");
+    assert_eq!(canvas_title(&app), "Something failed");
 }
 
 #[test]
@@ -719,7 +772,7 @@ fn message_lines_success_mode() {
         title: "Done".to_string(),
         lines: vec!["line1".to_string(), "line2".to_string()],
     }));
-    let lines = app.message_lines();
+    let lines = canvas_lines(&app);
     assert_eq!(lines, vec!["line1".to_string(), "line2".to_string()]);
 }
 
@@ -741,7 +794,7 @@ fn message_lines_form_mode_renders_fields() {
         pending: PendingAction::SaveConfig,
     };
     app.set_canvas_mode(CanvasMode::EditForm(form));
-    let lines = app.message_lines();
+    let lines = canvas_lines(&app);
     assert_eq!(lines.len(), 1);
     assert!(lines[0].contains("Host"));
 }

--- a/src/tui/types.rs
+++ b/src/tui/types.rs
@@ -28,7 +28,7 @@ pub struct Action {
     pub hotkey: &'static str,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Record {
     pub id: String,
     pub name: String,
@@ -125,6 +125,19 @@ pub enum FieldKind {
     Toggle,
     Choice(Vec<String>),
     Checkbox,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AppCommand {
+    Noop,
+    Quit,
+    BeginAction {
+        resource: ResourceKind,
+        action_index: usize,
+        selected_record: Option<Record>,
+    },
+    SubmitForm(FormState),
+    Confirm(PendingAction),
 }
 
 #[derive(Debug)]

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -1,8 +1,6 @@
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, ListItem},
 };
 
 use super::{
@@ -24,52 +22,6 @@ pub(crate) fn render_form_line(field: &FormField, selected: bool) -> String {
         FieldKind::Choice(_) | FieldKind::Text => field.value.clone(),
     };
     format!("{marker} {:<18} {}", field.label, value)
-}
-
-pub(crate) fn list_item(
-    label: &str,
-    meta: &str,
-    selected: bool,
-    accent: Color,
-) -> ListItem<'static> {
-    let style = if selected {
-        Style::default()
-            .bg(Color::Rgb(31, 48, 76))
-            .fg(Color::Rgb(237, 243, 255))
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(Color::Rgb(210, 219, 239))
-    };
-    ListItem::new(Line::from(vec![
-        Span::styled(label.to_string(), style),
-        Span::raw(" "),
-        Span::styled(meta.to_string(), Style::default().fg(accent)),
-    ]))
-}
-
-pub(crate) fn section_block<'a>(title: &'a str, meta: &'a str) -> Block<'a> {
-    Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Rgb(47, 58, 79)))
-        .style(Style::default().bg(Color::Rgb(18, 26, 39)))
-        .title(title_span(title, meta))
-}
-
-pub(crate) fn title_span<'a>(title: &'a str, meta: &'a str) -> Line<'a> {
-    let mut spans = vec![Span::styled(
-        title,
-        Style::default()
-            .fg(Color::Rgb(176, 188, 213))
-            .add_modifier(Modifier::BOLD),
-    )];
-    if !meta.is_empty() {
-        spans.push(Span::raw(" "));
-        spans.push(Span::styled(
-            meta,
-            Style::default().fg(Color::Rgb(121, 131, 151)),
-        ));
-    }
-    Line::from(spans)
 }
 
 pub(crate) fn field_line(label: &str, value: &str) -> Line<'static> {
@@ -115,31 +67,4 @@ pub(crate) fn muted_line(value: &str) -> Line<'static> {
         value.to_string(),
         Style::default().fg(Color::Rgb(121, 131, 151)),
     ))
-}
-
-pub(crate) fn focus_border(selected: bool) -> Style {
-    if selected {
-        Style::default().fg(Color::Rgb(145, 194, 255))
-    } else {
-        Style::default().fg(Color::Rgb(47, 58, 79))
-    }
-}
-
-pub(crate) fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
-    let popup = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Percentage((100 - percent_y) / 2),
-            Constraint::Percentage(percent_y),
-            Constraint::Percentage((100 - percent_y) / 2),
-        ])
-        .split(area);
-    Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage((100 - percent_x) / 2),
-            Constraint::Percentage(percent_x),
-            Constraint::Percentage((100 - percent_x) / 2),
-        ])
-        .split(popup[1])[1]
 }

--- a/src/tui_runtime.rs
+++ b/src/tui_runtime.rs
@@ -10,7 +10,7 @@ use ratatui::backend::CrosstermBackend;
 
 use crate::{
     conductor::TuiConductor,
-    tui::{draw, App, CanvasMode, Focus},
+    tui::{draw, App, AppCommand},
 };
 
 pub async fn run_tui(mut conductor: TuiConductor) -> Result<()> {
@@ -33,83 +33,63 @@ async fn run_app(
     loop {
         terminal.draw(|frame| draw(frame, &app))?;
 
-        if event::poll(std::time::Duration::from_millis(100))? {
-            let Event::Key(key) = event::read()? else {
-                continue;
-            };
+        let Some(key_code) = read_key_press(std::time::Duration::from_millis(100))? else {
+            continue;
+        };
 
-            if key.kind != KeyEventKind::Press {
-                continue;
-            }
-
-            match key.code {
-                KeyCode::Char('q') => break,
-                KeyCode::Char('j') | KeyCode::Down => match app.focus {
-                    Focus::Resources => app.next_resource(),
-                    Focus::Actions => app.next_action(),
-                    Focus::Form => app.form_next_field(),
-                    Focus::Records => app.next_record(),
-                },
-                KeyCode::Char('k') | KeyCode::Up => match app.focus {
-                    Focus::Resources => app.previous_resource(),
-                    Focus::Actions => app.previous_action(),
-                    Focus::Form => app.form_previous_field(),
-                    Focus::Records => app.previous_record(),
-                },
-                KeyCode::Char('h') | KeyCode::Left => {
-                    if app.focus == Focus::Form {
-                        app.form_toggle_or_cycle(false);
-                    } else {
-                        app.previous_resource();
-                    }
-                }
-                KeyCode::Char('l') | KeyCode::Right => {
-                    if app.focus == Focus::Form {
-                        app.form_toggle_or_cycle(true);
-                    } else {
-                        app.next_resource();
-                    }
-                }
-                KeyCode::Char('i') => app.toggle_inspector(),
-                KeyCode::Char('n') => app.focus = Focus::Actions,
-                KeyCode::Char('g') => app.focus = Focus::Resources,
-                KeyCode::Enter => match &app.canvas_mode {
-                    CanvasMode::Browse => {
-                        let mode = conductor.begin_action(
-                            app.active_resource(),
-                            app.selected_action,
-                            app.selected_record(),
-                        );
-                        app.set_canvas_mode(mode);
-                    }
-                    CanvasMode::EditForm(form) | CanvasMode::Setup(form) => {
-                        let next = conductor.submit_form(form).await;
-                        app.set_canvas_mode(next);
-                        app.sync_runtime(conductor.bootstrap_state());
-                    }
-                    CanvasMode::Confirm(confirm) => {
-                        let next = conductor.confirm(confirm.pending.clone()).await;
-                        app.set_canvas_mode(next);
-                        app.sync_runtime(conductor.bootstrap_state());
-                    }
-                    CanvasMode::Success(_) | CanvasMode::Error(_) => app.reset_to_browse(),
-                },
-                KeyCode::Esc => match app.canvas_mode {
-                    CanvasMode::Browse => {}
-                    CanvasMode::EditForm(_) | CanvasMode::Setup(_) | CanvasMode::Confirm(_) => {
-                        app.reset_to_browse()
-                    }
-                    CanvasMode::Success(_) | CanvasMode::Error(_) => app.reset_to_browse(),
-                },
-                KeyCode::Backspace if app.focus == Focus::Form => app.form_backspace(),
-                KeyCode::Char(' ') if app.focus == Focus::Form => app.form_toggle_or_cycle(true),
-                KeyCode::Char(ch) if app.focus == Focus::Form => app.form_insert_char(ch),
-                KeyCode::Tab => app.advance_focus(),
-                KeyCode::BackTab => app.reverse_focus(),
-                _ => {}
-            }
+        let command = app.handle_key(key_code);
+        if !handle_app_command(command, &mut app, conductor).await? {
+            break;
         }
     }
 
     Ok(())
+}
+
+fn read_key_press(timeout: std::time::Duration) -> Result<Option<KeyCode>> {
+    if !event::poll(timeout)? {
+        return Ok(None);
+    }
+
+    let Event::Key(key) = event::read()? else {
+        return Ok(None);
+    };
+
+    if key.kind != KeyEventKind::Press {
+        return Ok(None);
+    }
+
+    Ok(Some(key.code))
+}
+
+async fn handle_app_command(
+    command: AppCommand,
+    app: &mut App,
+    conductor: &mut TuiConductor,
+) -> Result<bool> {
+    match command {
+        AppCommand::Noop => Ok(true),
+        AppCommand::Quit => Ok(false),
+        AppCommand::BeginAction {
+            resource,
+            action_index,
+            selected_record,
+        } => {
+            let mode = conductor.begin_action(resource, action_index, selected_record.as_ref());
+            app.set_canvas_mode(mode);
+            Ok(true)
+        }
+        AppCommand::SubmitForm(form) => {
+            let next = conductor.submit_form(&form).await;
+            app.set_canvas_mode(next);
+            app.sync_runtime(conductor.bootstrap_state());
+            Ok(true)
+        }
+        AppCommand::Confirm(pending) => {
+            let next = conductor.confirm(pending).await;
+            app.set_canvas_mode(next);
+            app.sync_runtime(conductor.bootstrap_state());
+            Ok(true)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add responsive narrow, medium, and wide TUI shell layouts
- move runtime key handling through AppCommand so UI state transitions are testable
- expand TUI behavior coverage and isolate env-sensitive tests from ambient ZITADEL settings

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- git push origin HEAD
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/zitadel-tui/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
