### PR TITLE
fix: classify API app records

### DIFF
--- a/src/conductor/records.rs
+++ b/src/conductor/records.rs
@@ -3,36 +3,56 @@ use serde_json::Value;
 use crate::tui::Record;
 
 pub(crate) fn map_app_record(app: Value) -> Record {
-    let kind = app
-        .get("oidcConfig")
-        .and_then(|oidc| oidc.get("authMethodType"))
-        .and_then(|value| value.as_str())
-        .map(|value| {
-            if value == "OIDC_AUTH_METHOD_TYPE_NONE" {
-                "public".to_string()
-            } else {
-                "confidential".to_string()
-            }
-        })
-        .unwrap_or_else(|| "unknown".to_string());
-    let client_id = app
-        .get("oidcConfig")
-        .and_then(|oidc| oidc.get("clientId"))
-        .and_then(|value| value.as_str())
-        .unwrap_or("missing-client-id")
-        .to_string();
-    let redirect_count = app
-        .get("oidcConfig")
-        .and_then(|oidc| oidc.get("redirectUris"))
-        .and_then(|value| value.as_array())
-        .map(|uris| uris.len())
-        .unwrap_or(0);
+    let (kind, summary, detail) = if let Some(oidc_config) = app.get("oidcConfig") {
+        let kind = oidc_config
+            .get("authMethodType")
+            .and_then(|value| value.as_str())
+            .map(|value| {
+                if value == "OIDC_AUTH_METHOD_TYPE_NONE" {
+                    "public".to_string()
+                } else {
+                    "confidential".to_string()
+                }
+            })
+            .unwrap_or_else(|| "unknown".to_string());
+        let client_id = oidc_config
+            .get("clientId")
+            .and_then(|value| value.as_str())
+            .unwrap_or("missing-client-id")
+            .to_string();
+        let redirect_count = oidc_config
+            .get("redirectUris")
+            .and_then(|value| value.as_array())
+            .map(|uris| uris.len())
+            .unwrap_or(0);
+
+        (kind, format!("{redirect_count} redirects"), client_id)
+    } else if let Some(api_config) = app.get("apiConfig") {
+        let client_id = api_config
+            .get("clientId")
+            .and_then(|value| value.as_str())
+            .unwrap_or("missing-client-id")
+            .to_string();
+        let auth_method = api_config
+            .get("authMethodType")
+            .and_then(|value| value.as_str())
+            .unwrap_or("unknown-auth-method")
+            .to_string();
+
+        ("api".to_string(), auth_method, client_id)
+    } else {
+        (
+            "unknown".to_string(),
+            "0 redirects".to_string(),
+            "missing-client-id".to_string(),
+        )
+    };
     Record {
         id: string_field(&app, "id", "missing-id"),
         name: string_field(&app, "name", "unnamed"),
         kind,
-        summary: format!("{redirect_count} redirects"),
-        detail: client_id,
+        summary,
+        detail,
         changed_at: string_field(&app, "state", "unknown"),
     }
 }

--- a/src/conductor/tests.rs
+++ b/src/conductor/tests.rs
@@ -417,8 +417,28 @@ fn map_app_record_confidential_auth_method() {
 }
 
 #[test]
+fn map_app_record_extracts_api_fields() {
+    let app = serde_json::json!({
+        "id": "app-3",
+        "name": "Management API",
+        "state": "ACTIVE",
+        "apiConfig": {
+            "authMethodType": "API_AUTH_METHOD_TYPE_PRIVATE_KEY_JWT",
+            "clientId": "api-client-1"
+        }
+    });
+    let record = map_app_record(app);
+    assert_eq!(record.id, "app-3");
+    assert_eq!(record.name, "Management API");
+    assert_eq!(record.kind, "api");
+    assert_eq!(record.detail, "api-client-1");
+    assert_eq!(record.summary, "API_AUTH_METHOD_TYPE_PRIVATE_KEY_JWT");
+    assert_eq!(record.changed_at, "ACTIVE");
+}
+
+#[test]
 fn map_app_record_missing_oidc_config() {
-    let app = serde_json::json!({"id": "app-3", "name": "plain"});
+    let app = serde_json::json!({"id": "app-4", "name": "plain"});
     let record = map_app_record(app);
     assert_eq!(record.kind, "unknown");
     assert_eq!(record.detail, "missing-client-id");


### PR DESCRIPTION
Summary:
- Classify apiConfig-backed apps as API records instead of unknown.
- Display API client IDs and auth method summaries.
- Keep OIDC app classification covered by tests.

Verification:
- cargo fmt --check
- cargo test

Closes #89
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/zitadel-tui/pull/91" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
