### PR TITLE
fix: handle machine user records

### DIFF
--- a/src/conductor/records.rs
+++ b/src/conductor/records.rs
@@ -38,24 +38,62 @@ pub(crate) fn map_app_record(app: Value) -> Record {
 }
 
 pub(crate) fn map_user_record(user: Value) -> Record {
-    Record {
-        id: string_field(&user, "id", "missing-id"),
-        name: string_field(&user, "userName", "unknown-user"),
-        kind: string_field(&user, "state", "unknown"),
-        summary: user
-            .get("human")
+    let is_machine = user.get("machine").is_some();
+    let user_type = if is_machine { "machine" } else { "human" };
+    let state = string_field(&user, "state", "unknown");
+    let name = if is_machine {
+        user.get("machine")
+            .and_then(|machine| machine.get("name"))
+            .and_then(|name| name.as_str())
+            .unwrap_or_else(|| {
+                user.get("userName")
+                    .and_then(|user_name| user_name.as_str())
+                    .unwrap_or("unknown-user")
+            })
+            .to_string()
+    } else {
+        string_field(&user, "userName", "unknown-user")
+    };
+    let summary = if is_machine {
+        user.get("preferredLoginName")
+            .and_then(|login| login.as_str())
+            .or_else(|| {
+                user.get("loginNames")
+                    .and_then(|login_names| login_names.as_array())
+                    .and_then(|login_names| login_names.first())
+                    .and_then(|login| login.as_str())
+            })
+            .or_else(|| {
+                user.get("userName")
+                    .and_then(|user_name| user_name.as_str())
+            })
+            .unwrap_or("no login")
+            .to_string()
+    } else {
+        user.get("human")
             .and_then(|human| human.get("email"))
             .and_then(|email| email.get("email"))
             .and_then(|email| email.as_str())
             .unwrap_or("no email")
-            .to_string(),
-        detail: user
-            .get("human")
+            .to_string()
+    };
+    let detail = if is_machine {
+        "machine user".to_string()
+    } else {
+        user.get("human")
             .and_then(|human| human.get("profile"))
             .and_then(|profile| profile.get("displayName"))
             .and_then(|display_name| display_name.as_str())
             .unwrap_or("human user")
-            .to_string(),
+            .to_string()
+    };
+
+    Record {
+        id: string_field(&user, "id", "missing-id"),
+        name,
+        kind: format!("{user_type} {state}"),
+        summary,
+        detail,
         changed_at: "loaded".to_string(),
     }
 }

--- a/src/conductor/tests.rs
+++ b/src/conductor/tests.rs
@@ -440,16 +440,53 @@ fn map_user_record_extracts_human_fields() {
     let record = map_user_record(user);
     assert_eq!(record.id, "user-1");
     assert_eq!(record.name, "admin");
-    assert_eq!(record.kind, "ACTIVE");
+    assert_eq!(record.kind, "human ACTIVE");
     assert_eq!(record.summary, "admin@example.com");
     assert_eq!(record.detail, "Admin User");
     assert_eq!(record.changed_at, "loaded");
 }
 
 #[test]
-fn map_user_record_missing_human_fields() {
-    let user = serde_json::json!({"id": "user-2", "userName": "bot"});
+fn map_user_record_extracts_machine_fields() {
+    let user = serde_json::json!({
+        "id": "user-2",
+        "userName": "service-account",
+        "state": "ACTIVE",
+        "preferredLoginName": "service-account@example.com",
+        "loginNames": ["service-account@example.com", "service-account"],
+        "machine": {
+            "name": "cluster service account"
+        }
+    });
     let record = map_user_record(user);
+    assert_eq!(record.id, "user-2");
+    assert_eq!(record.name, "cluster service account");
+    assert_eq!(record.kind, "machine ACTIVE");
+    assert_eq!(record.summary, "service-account@example.com");
+    assert_eq!(record.detail, "machine user");
+    assert_eq!(record.changed_at, "loaded");
+}
+
+#[test]
+fn map_user_record_machine_falls_back_to_login_name() {
+    let user = serde_json::json!({
+        "id": "user-3",
+        "userName": "worker",
+        "loginNames": ["worker@example.com"],
+        "machine": {}
+    });
+    let record = map_user_record(user);
+    assert_eq!(record.name, "worker");
+    assert_eq!(record.kind, "machine unknown");
+    assert_eq!(record.summary, "worker@example.com");
+    assert_eq!(record.detail, "machine user");
+}
+
+#[test]
+fn map_user_record_missing_human_fields() {
+    let user = serde_json::json!({"id": "user-4", "userName": "bot"});
+    let record = map_user_record(user);
+    assert_eq!(record.kind, "human unknown");
     assert_eq!(record.summary, "no email");
     assert_eq!(record.detail, "human user");
 }


### PR DESCRIPTION
Summary:
- Distinguish human and machine users in TUI records.
- Show machine names and preferred login details for machine users.
- Keep human email and profile display covered by tests.

Verification:
- cargo fmt
- cargo test conductor::tests::map_user_record
- cargo test
- cargo clippy --all-targets

Closes #87
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/zitadel-tui/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
