### PR TITLE
🧪 [testing improvement] Add test for whoami

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -322,6 +322,25 @@ mod tests {
     use mockito::{Matcher, Server};
 
     #[tokio::test]
+    async fn whoami_sends_bearer_token_and_parses_result() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", "/auth/v1/users/me")
+            .match_header("authorization", "Bearer test-token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"id":"user-1","username":"test-user"}"#)
+            .create_async()
+            .await;
+
+        let client = ZitadelClient::new(server.url(), "test-token".to_string()).unwrap();
+        let user_info = client.whoami().await.unwrap();
+
+        mock.assert_async().await;
+        assert_eq!(user_info["id"], "user-1");
+        assert_eq!(user_info["username"], "test-user");
+    }
+    #[tokio::test]
     async fn list_projects_sends_bearer_token_and_parses_results() {
         let mut server = Server::new_async().await;
         let mock = server


### PR DESCRIPTION
Added a missing mockito test in `src/client.rs` to verify that `whoami()` properly sends the bearer token in the `authorization` header and accurately parses the JSON response containing the ID and username. This enhances the API client test suite.

---
*PR created automatically by Jules for task [13368535145687699382](https://jules.google.com/task/13368535145687699382) started by @damacus*