### PR TITLE
🧪 Add test for regenerate_secret function

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -546,7 +546,10 @@ mod tests {
     async fn regenerate_secret_uses_expected_endpoint() {
         let mut server = Server::new_async().await;
         let mock = server
-            .mock("POST", "/management/v1/projects/project-1/apps/app-1/oidc/secret/_regenerate")
+            .mock(
+                "POST",
+                "/management/v1/projects/project-1/apps/app-1/oidc/secret/_regenerate",
+            )
             .match_header("authorization", "Bearer test-token")
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -555,7 +558,10 @@ mod tests {
             .await;
 
         let client = ZitadelClient::new(server.url(), "test-token".to_string()).unwrap();
-        let response = client.regenerate_secret("project-1", "app-1").await.unwrap();
+        let response = client
+            .regenerate_secret("project-1", "app-1")
+            .await
+            .unwrap();
 
         mock.assert_async().await;
         assert_eq!(response["clientSecret"], "new-secret");

--- a/src/client.rs
+++ b/src/client.rs
@@ -147,8 +147,8 @@ impl ZitadelClient {
 
     pub async fn regenerate_secret(&self, project_id: &str, app_id: &str) -> Result<Value> {
         self.api_request(
-            Method::PUT,
-            &format!("/management/v1/projects/{project_id}/apps/{app_id}/oidc_config/secret"),
+            Method::POST,
+            &format!("/management/v1/projects/{project_id}/apps/{app_id}/oidc/secret/_regenerate"),
             None,
         )
         .await
@@ -541,5 +541,23 @@ mod tests {
 
         mock.assert_async().await;
         assert_eq!(response["memberId"], "member-1");
+    }
+    #[tokio::test]
+    async fn regenerate_secret_uses_expected_endpoint() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/management/v1/projects/project-1/apps/app-1/oidc/secret/_regenerate")
+            .match_header("authorization", "Bearer test-token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"clientSecret":"new-secret"}"#)
+            .create_async()
+            .await;
+
+        let client = ZitadelClient::new(server.url(), "test-token".to_string()).unwrap();
+        let response = client.regenerate_secret("project-1", "app-1").await.unwrap();
+
+        mock.assert_async().await;
+        assert_eq!(response["clientSecret"], "new-secret");
     }
 }


### PR DESCRIPTION
🎯 **What:** 
Added a missing test for the `regenerate_secret` function in `src/client.rs`. During the testing process, it was also noticed that the actual implementation of `regenerate_secret` in the codebase used `PUT /oidc_config/secret`, which was different from the correct API endpoint specified in the task description. The function implementation was corrected to use `POST /oidc/secret/_regenerate` matching the issue description expectations.

📊 **Coverage:** 
- The new test mocks a `POST` request to `/management/v1/projects/{project_id}/apps/{app_id}/oidc/secret/_regenerate`.
- It validates the response JSON is correctly parsed, specifically asserting the newly generated `clientSecret` matches the mock payload.
- It tests that the function sends the correct `authorization` headers to the API endpoint.

✨ **Result:** 
- The functionality for `regenerate_secret` is now explicitly tested against regressions, ensuring it interacts correctly with the appropriate Zitadel endpoint.

---
*PR created automatically by Jules for task [1919931740695458831](https://jules.google.com/task/1919931740695458831) started by @damacus*