### PR TITLE
⚡ Optimize QuickSetup with Concurrent User Creation

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Context, Result};
 use reqwest::{Client, Method};
 use serde_json::{json, Value};
 
+#[derive(Clone)]
 pub struct ZitadelClient {
     http: Client,
     base_url: String,

--- a/src/commands/users.rs
+++ b/src/commands/users.rs
@@ -45,18 +45,30 @@ pub async fn execute_users_command(
         UsersAction::GrantIamOwner(grant) => client.grant_iam_owner(&grant.user_id).await,
         UsersAction::QuickSetup => {
             let templates = config.templates()?;
-            let mut created = Vec::new();
-            for user in templates.users {
-                let result = client
-                    .create_human_user(&user.email, &user.first_name, &user.last_name, None)
-                    .await?;
-                if user.admin {
-                    if let Some(user_id) = result.get("userId").and_then(|value| value.as_str()) {
-                        client.grant_iam_owner(user_id).await?;
+            let mut join_set = tokio::task::JoinSet::new();
+
+            for (index, user) in templates.users.into_iter().enumerate() {
+                let client = client.clone();
+                join_set.spawn(async move {
+                    let result = client
+                        .create_human_user(&user.email, &user.first_name, &user.last_name, None)
+                        .await?;
+                    if user.admin {
+                        if let Some(user_id) = result.get("userId").and_then(|value| value.as_str()) {
+                            client.grant_iam_owner(user_id).await?;
+                        }
                     }
-                }
-                created.push(result);
+                    Ok::<_, anyhow::Error>((index, result))
+                });
             }
+
+            let mut results = Vec::new();
+            while let Some(res) = join_set.join_next().await {
+                results.push(res??);
+            }
+            results.sort_by_key(|(idx, _)| *idx);
+
+            let created: Vec<Value> = results.into_iter().map(|(_, val)| val).collect();
             Ok(Value::Array(created))
         }
     }

--- a/src/commands/users.rs
+++ b/src/commands/users.rs
@@ -54,7 +54,8 @@ pub async fn execute_users_command(
                         .create_human_user(&user.email, &user.first_name, &user.last_name, None)
                         .await?;
                     if user.admin {
-                        if let Some(user_id) = result.get("userId").and_then(|value| value.as_str()) {
+                        if let Some(user_id) = result.get("userId").and_then(|value| value.as_str())
+                        {
                             client.grant_iam_owner(user_id).await?;
                         }
                     }


### PR DESCRIPTION
💡 **What:** Refactored `UsersAction::QuickSetup` in `src/commands/users.rs` to process user creation concurrently using `tokio::task::JoinSet`. Additionally, added `#[derive(Clone)]` to `ZitadelClient` in `src/client.rs` to enable passing the client to the spawned tasks safely.

🎯 **Why:** The previous implementation sequentially iterated over `templates.users` executing `client.create_human_user` and `client.grant_iam_owner` for each. This resulted in an N+1 API request pattern, significantly degrading performance when creating multiple users. Concurrent execution allows independent network requests to run in parallel, avoiding idle wait times.

📊 **Measured Improvement:** The sequential version scales linearly, O(N), blocking on each network roundtrip. The optimized version delegates the I/O waits concurrently via Tokio, bringing the theoretical execution time closer to O(1) bound by max concurrent connection limits or API rate limits. No formal benchmark was added because the optimization is straightforward concurrency for network I/O, but local execution validates functionality is unchanged.

---
*PR created automatically by Jules for task [16372981441485857094](https://jules.google.com/task/16372981441485857094) started by @damacus*