### PR TITLE
docs: clarify authentication recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Current status:
 
 - Rust crate, TUI, CLI, and release automation are the only supported runtime path
 - runtime config is TOML-only in the XDG config directory
-- PAT, service-account, and OAuth Device Flow (OIDC) authentication are supported
+- service-account JSON authentication is recommended for administration; PATs
+  are supported for compatibility, and OAuth Device Flow is available for
+  limited interactive/session use
 - app and user templates remain YAML-based
 
 ## Features
@@ -37,9 +39,11 @@ Current status:
 - **Configuration and Auth**
   - TOML config in XDG config space
   - auth precedence `CLI > env > config > session token`
-  - PAT precedence over service-account credentials within each source
-  - PAT, service-account file, and OAuth Device Flow (`auth login`) support
-  - session tokens cached in `~/.config/zitadel-tui/tokens.json` with auto-refresh
+  - PAT credentials are checked before service-account credentials
+  - service-account JSON authentication for administrative workflows
+  - PAT support for compatibility and quick/manual use
+  - OAuth Device Flow (`auth login`) for limited interactive/session use
+  - OIDC session tokens cached in `~/.config/zitadel-tui/tokens.json` with auto-refresh
 
 ## Installation
 
@@ -253,12 +257,14 @@ Example: `zitadel-tui idps configure-google --client-id google-client-id --clien
 #### `auth`
 
 `auth login`
-: Authenticate via the OAuth 2.0 Device Authorization Grant. Prints a URL and
-short code, waits for browser approval, then saves the access and refresh tokens
-to `~/.config/zitadel-tui/tokens.json`. Requires a Zitadel native app with the
-Device Code grant enabled and JWT access tokens configured for API access.
-The `apps create-native --device-code` path is intended for CLI login sessions
-and saves the returned client ID for future logins.
+: Authenticate via the OAuth 2.0 Device Authorization Grant for limited
+interactive/session use. Prints a URL and short code, waits for browser
+approval, then saves the access and refresh tokens to
+`~/.config/zitadel-tui/tokens.json`. Requires a Zitadel native app with the
+Device Code grant enabled and JWT access tokens configured for userinfo access.
+The cached session is usable for `auth status`, `auth login`, and `auth logout`
+only; use service-account JSON or PAT credentials for app, user, IDP, and admin
+API operations.
 Example: `zitadel-tui --host https://zitadel.example.com auth login`
 
 `--client-id <CLIENT_ID>`
@@ -335,33 +341,88 @@ users:
 
 ## Authentication
 
+`zitadel-tui` is intended for administrative Zitadel workflows. For admin use,
+authenticate with a Zitadel service-account JSON key.
+
 Authentication is resolved in this order:
 
 1. `--token` / `ZITADEL_TOKEN` / `pat` in config (PAT)
 2. `--service-account-file` / `ZITADEL_SERVICE_ACCOUNT_FILE` / `service_account_file` in config
 3. Cached session token from `auth login` (with automatic refresh)
 
-### OAuth Device Flow (recommended for interactive use)
+This is resolution order, not recommendation order. PAT values are checked first
+for compatibility, but service-account JSON keys are preferred for regular
+administrative use.
 
-Register a native app in your Zitadel instance with the **Device Code** grant
-type enabled and JWT access tokens enabled, then log in once:
+### Recommended: Service-Account JSON Key
+
+Service-account authentication uses a private key JWT flow: the CLI signs a
+short-lived assertion with the private key from the JSON key file, exchanges it
+with Zitadel for an access token, and uses that token for API calls.
+
+This is the recommended authentication method for:
+
+- managing OIDC applications
+- creating and updating users
+- configuring identity providers
+- bootstrap and recovery workflows
+- repeatable automation
 
 ```bash
-zitadel-tui --host https://zitadel.example.com apps create-native --name zitadel-tui --device-code
+zitadel-tui \
+  --host https://zitadel.example.com \
+  --service-account-file ./service-account.json \
+  auth status
+```
+
+The same value can be configured with:
+
+```bash
+export ZITADEL_SERVICE_ACCOUNT_FILE=./service-account.json
+```
+
+or in `~/.config/zitadel-tui/config.toml`:
+
+```toml
+zitadel_url = "https://zitadel.example.com"
+service_account_file = "/path/to/service-account.json"
+```
+
+### Supported: Personal Access Token
+
+PAT authentication remains supported for compatibility, quick testing, and
+manual workflows.
+
+PATs are bearer tokens: anyone with the token can use it directly until it
+expires or is revoked. Prefer service-account JSON keys for regular
+administrative use.
+
+```bash
+zitadel-tui \
+  --host https://zitadel.example.com \
+  --token "$ZITADEL_TOKEN" \
+  auth status
+```
+
+### Limited: OAuth Device Flow
+
+Register a native app in your Zitadel instance with the **Device Code** grant
+type enabled and JWT access tokens enabled, then log in:
+
+```bash
 zitadel-tui --host https://zitadel.example.com auth login
 ```
 
 The command prints a URL and a short code. Open the URL in your browser,
 enter the code, and approve the request. The CLI polls in the background and
-saves the access and refresh tokens to
-`~/.config/zitadel-tui/tokens.json` (mode `0600`).
+saves the access and refresh tokens to `~/.config/zitadel-tui/tokens.json`
+(mode `0600`).
 
-After login, subsequent commands use the cached token automatically:
-
-```bash
-zitadel-tui --host https://zitadel.example.com apps list
-zitadel-tui --host https://zitadel.example.com auth status
-```
+OAuth Device Flow is available for limited interactive/session use, but it is
+not the recommended authentication method for administration. Cached OIDC
+sessions can run `auth status`, `auth login`, and `auth logout`; app, user, IDP,
+Auth API, Management API, and Admin API operations require service-account JSON
+or PAT credentials.
 
 Tokens are silently refreshed when they expire. Log out with:
 
@@ -380,6 +441,23 @@ The session token cache lives at:
 It is created with mode `0600`. The cache stores the access token, refresh
 token, expiry timestamp, client ID, and host. The `device_client_id` config
 field remembers your client ID so you only need `--client-id` once.
+
+### ZITADEL Chart v10 Login Service Key
+
+The ZITADEL Helm chart v10 uses an internal login-service keypair for the hosted
+Login UI. That keypair is not used by `zitadel-tui`.
+
+Do not confuse these credentials:
+
+- `zitadel-login-service-key`: internal Kubernetes/chart credential for the
+  hosted ZITADEL Login UI
+- service-account JSON key: client-side admin credential for tools like
+  `zitadel-tui`
+- public HTTPS certificate: browser/client TLS for your Zitadel URL
+
+`zitadel-tui` should authenticate with a Zitadel service-account JSON key for
+administrative workflows. Do not reuse the chart's `zitadel-login-service-key`
+certificate or private key as a CLI credential.
 
 ## Docker
 

--- a/site_docs/authentication.md
+++ b/site_docs/authentication.md
@@ -1,23 +1,80 @@
 # Authentication
 
-Most `zitadel-tui` commands need a Zitadel host and an access token before they
-can call admin APIs.
+`zitadel-tui` is intended for administrative Zitadel workflows. For admin use,
+authenticate with a Zitadel service-account JSON key.
 
-Set the host with `--host`, `ZITADEL_URL`, or `zitadel_url` in
+Most commands need a Zitadel host and API credentials before they can call admin
+APIs. Set the host with `--host`, `ZITADEL_URL`, or `zitadel_url` in
 `~/.config/zitadel-tui/config.toml`:
 
 ```bash
 zitadel-tui --host https://zitadel.example.com auth status
 ```
 
-## Recommended: Browser Login
+## Recommended: Service-Account JSON Key
 
-Use browser login for interactive administrator sessions.
+Service-account authentication uses a private key JWT flow: the CLI signs a
+short-lived assertion with the private key from the JSON key file, exchanges it
+with Zitadel for an access token, and uses that token for API calls.
+
+This is the recommended authentication method for:
+
+- managing OIDC applications
+- creating and updating users
+- configuring identity providers
+- bootstrap and recovery workflows
+- repeatable automation
+
+```bash
+zitadel-tui \
+  --host https://zitadel.example.com \
+  --service-account-file ./service-account.json \
+  auth status
+```
+
+You can also set the file path with `ZITADEL_SERVICE_ACCOUNT_FILE` or
+`service_account_file` in config:
+
+```toml
+zitadel_url = "https://zitadel.example.com"
+service_account_file = "/path/to/service-account.json"
+```
+
+## Supported: Personal Access Token
+
+PAT authentication remains supported for compatibility, quick testing, and
+manual workflows.
+
+PATs are bearer tokens: anyone with the token can use it directly until it
+expires or is revoked. Prefer service-account JSON keys for regular
+administrative use.
+
+```bash
+zitadel-tui \
+  --host https://zitadel.example.com \
+  --token "$ZITADEL_TOKEN" \
+  auth status
+```
+
+You can also set the token with `ZITADEL_TOKEN` or `pat` in config.
+
+## Limited: OAuth Device Flow
+
+OAuth Device Flow is available for limited interactive/session use. It is not
+the recommended authentication method for administration.
+
+Cached OIDC sessions can run:
+
+- `auth login`
+- `auth logout`
+- `auth status`
+
+App, user, IDP, Auth API, Management API, and Admin API operations require
+service-account JSON or PAT credentials.
 
 Browser login requires a Zitadel native app with the Device Code grant enabled
-and JWT access tokens enabled for API access.
-
-If you already have another CLI credential, create the native app from the CLI:
+and JWT access tokens enabled for userinfo access. If you already have admin API
+credentials, create the native app from the CLI:
 
 ```bash
 zitadel-tui --host https://zitadel.example.com apps create-native \
@@ -38,41 +95,8 @@ browser, then the CLI stores the session in:
 ~/.config/zitadel-tui/tokens.json
 ```
 
-Future commands use the cached session automatically:
-
-```bash
-zitadel-tui --host https://zitadel.example.com apps list
-zitadel-tui --host https://zitadel.example.com users list
-```
-
 If `--client-id` is omitted, `zitadel-tui` uses `device_client_id` from config.
 If that is also absent, it prompts for the client ID and saves it for later.
-
-## Alternative: Personal Access Token
-
-Use a personal access token when you want to pass an existing administrator
-token directly.
-
-```bash
-zitadel-tui --host https://zitadel.example.com \
-  --token "$ZITADEL_PAT" \
-  auth status
-```
-
-You can also set the token with `ZITADEL_TOKEN` or `pat` in config.
-
-## Alternative: Service Account File
-
-Use a service account file for non-interactive administrator workflows.
-
-```bash
-zitadel-tui --host https://zitadel.example.com \
-  --service-account-file ./service-account.json \
-  auth status
-```
-
-You can also set the file path with `ZITADEL_SERVICE_ACCOUNT_FILE` or
-`service_account_file` in config.
 
 ## Check Current Authentication
 
@@ -113,6 +137,27 @@ exact order:
 6. `service_account_file` in config
 7. Cached session token from `auth login`
 
+This is resolution order, not recommendation order. PAT values are checked
+first for compatibility, but service-account JSON keys are preferred for
+regular administrative use.
+
 The cached session token is used only for the same Zitadel host it was created
 for. If the cached access token is expired and a refresh token is available,
 `zitadel-tui` refreshes it automatically.
+
+## ZITADEL Chart v10 Login Service Key
+
+The ZITADEL Helm chart v10 uses an internal login-service keypair for the hosted
+Login UI. That keypair is not used by `zitadel-tui`.
+
+Do not confuse these credentials:
+
+- `zitadel-login-service-key`: internal Kubernetes/chart credential for the
+  hosted ZITADEL Login UI
+- service-account JSON key: client-side admin credential for tools like
+  `zitadel-tui`
+- public HTTPS certificate: browser/client TLS for your Zitadel URL
+
+`zitadel-tui` should authenticate with a Zitadel service-account JSON key for
+administrative workflows. Do not reuse the chart's `zitadel-login-service-key`
+certificate or private key as a CLI credential.

--- a/site_docs/configuration.md
+++ b/site_docs/configuration.md
@@ -29,15 +29,17 @@ omitted.
 : Personal access token used when `--token` and `ZITADEL_TOKEN` are not set.
 
 `service_account_file`
-: Path to a Zitadel service-account JSON key file used when PAT credentials are
-not provided by CLI, environment, or config.
+: Path to a Zitadel service-account JSON key file. This is the recommended
+credential for administrative workflows.
 
 `device_client_id`
 : Client ID of the Zitadel native app used for `auth login` (OAuth Device Flow).
 Written automatically when you run `auth login` and enter the client ID
 interactively, or when `apps create-native --device-code` returns a client ID.
 Can be set in advance to skip the prompt. Not a secret — this is a public client
-with no `client_secret`.
+with no `client_secret`. OIDC Device Flow sessions are limited to `auth login`,
+`auth logout`, and `auth status`; app, user, IDP, and admin API operations
+require service-account JSON or PAT credentials.
 
 ## Apps and users templates
 
@@ -82,8 +84,8 @@ Authentication is resolved in this order:
 3. TOML config
 4. Cached session token (`auth login`)
 
-Within each source, PAT credentials are checked before service-account
-credentials.
+PAT credentials are checked before service-account credentials. This is
+resolution order, not recommendation order.
 
 Resolution order in practice:
 
@@ -96,14 +98,17 @@ Resolution order in practice:
 7. Session token from `~/.config/zitadel-tui/tokens.json` (with auto-refresh)
 
 See [Authentication](authentication.md) for login commands and credential
-examples.
+examples, including the recommended service-account JSON key path for
+administrative workflows.
 
 ## Token cache
 
-`auth login` saves tokens to `~/.config/zitadel-tui/tokens.json` (mode `0600`).
-The cache stores:
+`auth login` saves OIDC session tokens to
+`~/.config/zitadel-tui/tokens.json` (mode `0600`). These tokens are used for
+limited interactive/session commands, not for app, user, IDP, or admin API
+operations. The cache stores:
 
-- `access_token` — bearer token used for API calls
+- `access_token` — bearer token used for supported OIDC session checks
 - `refresh_token` — used to silently obtain a new access token when it expires
 - `expires_at` — unix timestamp; the access token is refreshed automatically
   when this is in the past
@@ -139,6 +144,7 @@ Example: `zitadel-tui --config ./config.toml`
 - `auth status`, `auth logout`, and `config show` have no command-specific flags
 - `auth login` saves `device_client_id` to the canonical config path if you
   enter it interactively. `apps create-native --device-code` also saves the
-  returned client ID. Subsequent logins only need `auth login` with no flags
+  returned client ID. Subsequent OIDC session logins only need `auth login`
+  with no flags
 - The token cache is host-specific; running `auth login` against a different
   host overwrites the cache

--- a/site_docs/index.md
+++ b/site_docs/index.md
@@ -26,8 +26,10 @@ identity providers, and runtime configuration.
 - **Configuration and Auth**
   - Canonical TOML config in XDG config space
   - Auth precedence `CLI > env > config > session token`
-  - PAT precedence over service-account credentials within each source
-  - PAT, service-account file, and OAuth Device Flow (`auth login`) authentication are supported
+  - PAT credentials are checked before service-account credentials
+  - Service-account JSON authentication is recommended for administration
+  - PAT authentication is supported for compatibility and quick/manual use
+  - OAuth Device Flow (`auth login`) is available for limited interactive/session use
 
 ## Quick Start
 
@@ -109,7 +111,8 @@ Templates for apps and users remain YAML-based.
 ## Requirements
 
 - Rust 1.89 or newer
-- A Zitadel PAT, service account file, or a native app configured for Device Code login
+- A Zitadel service-account JSON key for administration, or a PAT for
+  compatibility and quick/manual use
 
 ## License
 

--- a/site_docs/installation.md
+++ b/site_docs/installation.md
@@ -76,7 +76,8 @@ zitadel-tui config show
 ## Requirements
 
 - Rust 1.89 or newer
-- A Zitadel personal access token or service account file
+- A Zitadel service-account JSON key for administration, or a PAT for
+  compatibility and quick/manual use
 
 See [Authentication](authentication.md) for supported CLI authentication
 methods.

--- a/site_docs/oidc-apps.md
+++ b/site_docs/oidc-apps.md
@@ -10,16 +10,15 @@ OIDC applications in `zitadel-tui`.
 You need:
 
 - a Zitadel host URL
-- either a PAT, a service-account JSON file, or a working device-flow login
+- a service-account JSON key, or a PAT for compatibility and quick/manual use
 - an optional `apps.yml` if you want template-based quick setup
 
 Why this can feel harder than it should:
 
-- there are three authentication paths: PAT, service account, and device flow
-- the TUI setup screen still labels OAuth device as a placeholder, so the login
-  journey is not fully explained in-canvas
-- device-flow login is CLI-only and requires a native app that already has
-  Device Code enabled and JWT access tokens configured
+- the credential that is best for app administration is the service-account
+  JSON key, even though PATs are still checked first by the resolver
+- OIDC Device Flow is limited to `auth login`, `auth logout`, and `auth status`;
+  it does not run app administration commands
 - application settings are not editable in place today; if redirect URIs or the
   client type change, the current workflow is to recreate the app
 
@@ -118,12 +117,11 @@ zitadel-tui apps quick-setup --names grafana,paperless,nextcloud
 
 For the smoothest path today:
 
-1. Use a PAT if you already have one.
-2. Use a service-account file if this is automation or shared admin tooling.
-3. Use device flow only after creating a native app with `--device-code`, then
-   run `zitadel-tui auth login`.
+1. Use a service-account JSON key for regular administration, automation, and
+   shared admin tooling.
+2. Use a PAT when you need compatibility or quick/manual access.
+3. Use device flow only for `auth login`, `auth logout`, and `auth status`.
 
-If `auth login` succeeds in the browser but still fails in the CLI, the usual
-cause is that the native app is returning an access token format the Zitadel
-management APIs cannot use. In this project, that means the native app needs
-Device Code enabled and JWT access tokens, not an opaque token.
+If `auth login` succeeds, the cached OIDC session still cannot run app
+administration commands. Use service-account JSON or PAT credentials for the
+commands in this guide.


### PR DESCRIPTION
## Summary
- recommend service-account JSON key auth for administrative workflows
- document PAT as a compatibility/manual fallback
- clarify OIDC Device Flow is limited to auth login/logout/status and add the chart v10 login-service key warning

## Verification
- rg stale-auth-language consistency pass
- git diff --check

Docs site build was not run because zensical is not installed locally.